### PR TITLE
Update sdb_fdw.c

### DIFF
--- a/driver/postgresql/sdb_fdw.c
+++ b/driver/postgresql/sdb_fdw.c
@@ -917,6 +917,8 @@ void sdbGetColumnKeyInfo( SdbExecState *fdw_state )
    sdbbson_destroy( &condition ) ;
    sdbbson_destroy( &selector ) ;
    sdbbson_destroy( &ShardingKey ) ;
+   
+   sdbCloseCursor( cursor ) ;
 }
 
 bool sdbIsShardingKeyChanged( SdbExecState *fdw_state, sdbbson *oldBson, 


### PR DESCRIPTION
cursor is not released, will cause memory leak in SequoiaDB server side