### PR TITLE
let the complier work

### DIFF
--- a/SequoiaDB/engine/include/ossVer.h
+++ b/SequoiaDB/engine/include/ossVer.h
@@ -77,6 +77,14 @@
       Build time
 */
 
+#ifdef _DEBUG
+   #define SDB_ENGINE_BUILD_TIME SDB_ENGINE_BUILD_CURRENT"(Debug)"
+#else
+   #define SDB_ENGINE_BUILD_TIME SDB_ENGINE_BUILD_CURRENT
+#endif
+   
+
+
 /*
  *    Get the version, subversion and release version.
  */


### PR DESCRIPTION
i find it can't Compile for missing micro "SDB_ENGINE_BUILD_TIME" in ossVer.h. i add it in, and it works