### PR TITLE
feat(lob): improve bucket hash balance and add lob data page CRC checksum

### DIFF
--- a/SequoiaDB/engine/dms/dmsDump.cpp
+++ b/SequoiaDB/engine/dms/dmsDump.cpp
@@ -2256,7 +2256,8 @@ UINT32 _dmsDump::dumpDmsLobData( CHAR *inBuf, UINT32 inSize,
 
 UINT32 _dmsDump::dumpDmsLobDataMapBlk( UINT32 pageID, dmsLobDataMapBlk *blk, CHAR * outBuf,
                                        UINT32 outSize, CHAR * addrPrefix,
-                                       UINT32 options, UINT32 pageSize)
+                                       UINT32 options, UINT32 pageSize,
+                                       UTIL_LOB_HASH_TYPE hashType )
 {
    SDB_ASSERT( blk, "blk can't be null" ) ;
    SDB_ASSERT( outBuf, "outBuf can't be null" ) ;
@@ -2287,7 +2288,7 @@ UINT32 _dmsDump::dumpDmsLobDataMapBlk( UINT32 pageID, dmsLobDataMapBlk *blk, CHA
    {
       const char *tag = NULL ;
       len += ossSnprintf(outBuf + len, outSize -len, "Lobm dmsLobDataMapBlk (%u):" OSS_NEWLINE, pageID );
-      UINT32 bucketID = dmsStorageLob::getBucketID( *blk ) ;
+      UINT32 bucketID = dmsStorageLob::getBucketID( *blk, hashType ) ;
       bson::OID oid;
       ossMemcpy(&oid, blk->_oid, DMS_LOB_OID_LEN) ;
       len += ossSnprintf(outBuf + len, outSize -len,  " BucketID       : %u" OSS_NEWLINE, bucketID ) ;
@@ -2304,6 +2305,14 @@ UINT32 _dmsDump::dumpDmsLobDataMapBlk( UINT32 pageID, dmsLobDataMapBlk *blk, CHA
 
       tag = blk->isNew()? "DMS_LOB_PAGE_NEW":"DMS_LOB_PAGE_OLD";
       len += ossSnprintf(outBuf + len, outSize - len, " New Flag       : %s (%u)" OSS_NEWLINE, tag, blk->_newFlag ) ;
+
+      tag = ( DMS_LOB_PAGE_CRC_FULL == blk->_crcFlag ) ?
+            "DMS_LOB_PAGE_CRC_FULL" : "DMS_LOB_PAGE_CRC_NONE" ;
+      len += ossSnprintf(outBuf + len, outSize - len, " CRC Flag       : %s (%u)" OSS_NEWLINE, tag, blk->_crcFlag ) ;
+      if ( DMS_LOB_PAGE_CRC_FULL == blk->_crcFlag )
+      {
+         len += ossSnprintf(outBuf + len, outSize - len, " CRC            : 0x%08x" OSS_NEWLINE, blk->_crc ) ;
+      }
    }
 
    len += ossSnprintf ( outBuf + len, outSize - len, OSS_NEWLINE ) ;

--- a/SequoiaDB/engine/dms/dmsStorageLob.cpp
+++ b/SequoiaDB/engine/dms/dmsStorageLob.cpp
@@ -58,14 +58,6 @@ namespace engine
    #define DMS_LOB_PAGE_IN_USED( page )\
            ( DMS_SME_ALLOCATED == getSME()->getBitMask( page ) )
 
-   #define DMS_LOB_GET_HASH_FROM_BLK( blk, hash )\
-           do\
-           {\
-              const BYTE *d1 = (blk)->_oid ;\
-              const BYTE *d2 = ( const BYTE * )( &( (blk)->_sequence ) ) ;\
-              (hash) = ossHash( d1, sizeof( (blk)->_oid ),\
-                                d2, sizeof( (blk)->_sequence ) ) ;\
-           } while( FALSE )
 
    /*
       _dmsStorageLob implement
@@ -92,6 +84,8 @@ namespace engine
       _dmsData->_attachLob( this ) ;
       _isRename = FALSE ;
       _dataSegmentSize = 0 ;
+      /// default to current version, refreshed from header in _onOpened
+      _hashVersion = DMS_LOB_CUR_VERSION ;
    }
 
    _dmsStorageLob::~_dmsStorageLob()
@@ -124,10 +118,10 @@ namespace engine
       _path = NULL ;
    }
 
-   UINT32 _dmsStorageLob::getBucketID( const _dmsLobDataMapBlk &blk )
+   UINT32 _dmsStorageLob::getBucketID( const _dmsLobDataMapBlk &blk,
+                                       UTIL_LOB_HASH_TYPE hashType )
    {
-      UINT32 hashCode = 0 ;
-      DMS_LOB_GET_HASH_FROM_BLK( &blk, hashCode ) ;
+      UINT32 hashCode = utilLobHash( blk._oid, blk._sequence, hashType ) ;
       return _getBucket( hashCode ) ;
    }
 
@@ -557,7 +551,7 @@ namespace engine
       UINT32 readSz = 0 ;
       dmsLobRecord piece ;
       piece.set( &oid, DMS_LOB_META_SEQUENCE, 0,
-                 sizeof( meta ), NULL ) ;
+                 sizeof( meta ), NULL, hashType() ) ;
       rc = read( piece, mbContext, cb,
                  ( CHAR * )( &meta ), readSz ) ;
       if ( SDB_OK == rc )
@@ -601,7 +595,7 @@ namespace engine
       PD_TRACE_ENTRY( SDB__DMSSTORAGELOB_WRITELOBMETA ) ;
       dmsLobRecord piece ;
       piece.set( &oid, DMS_LOB_META_SEQUENCE, 0,
-                 sizeof( meta ), ( const CHAR * )( &meta ) ) ;
+                 sizeof( meta ), ( const CHAR * )( &meta ), hashType() ) ;
       if ( isNew )
       {
          rc = write( piece, mbContext, cb, dpsCB ) ;
@@ -984,6 +978,21 @@ namespace engine
          blk->setOld() ;
       }
 
+      /// Maintain the page crc. Only a full overwrite ( from offset 0 that
+      /// covers the whole valid content ) can be checksummed without an
+      /// extra read; any other partial update changes the page content, so
+      /// the crc must be cleared to avoid a stale value ( see design ).
+      if ( pmdGetOptionCB()->lobChecksumWriteOn() &&
+           0 == record._offset && record._dataLen >= orgBlkLen &&
+           NULL != record._data && record._dataLen > 0 )
+      {
+         blk->setCrc( utilCrc32c( record._data, record._dataLen ) ) ;
+      }
+      else
+      {
+         blk->clearCrc() ;
+      }
+
       mbContext->mbStat()->addTotalLobSize( pageIncSize ) ;
 
       _incWriteRecord() ;
@@ -1304,6 +1313,10 @@ namespace engine
       DMS_LOB_PAGEID page = DMS_LOB_INVALID_PAGEID ;
       BOOLEAN locked = FALSE ;
       utilCacheContext cContext ;
+      /// crc verify is done after submit ( data filled in buf ), so capture
+      /// the expected crc under mb lock here
+      BOOLEAN verifyCrc = FALSE ;
+      UINT32  expectCrc = 0 ;
 
       if ( _needDelayOpen )
       {
@@ -1355,6 +1368,21 @@ namespace engine
 #if defined (_DEBUG)
       SDB_ASSERT( DMS_LOB_PAGE_IN_USED( page ), "must be used" ) ;
 #endif
+      /// A whole page read ( offset 0, len == page data len ) with a valid
+      /// page crc can be verified. Capture the expected crc under lock.
+      if ( pmdGetOptionCB()->lobChecksumReadOn() && 0 == record._offset )
+      {
+         dmsExtRW extRW = extent2RW( page, mbContext->mbID() ) ;
+         extRW.setNothrow( TRUE ) ;
+         const _dmsLobDataMapBlk *blk = extRW.readPtr<_dmsLobDataMapBlk>() ;
+         if ( blk && blk->isCrcValid() &&
+              record._dataLen == blk->_dataLen )
+         {
+            verifyCrc = TRUE ;
+            expectCrc = blk->_crc ;
+         }
+      }
+
       _pCacheUnit->prepareRead( page, record._offset, record._dataLen,
                                 cb, cContext ) ;
       rc = cContext.read( buf, record._offset, record._dataLen, cb ) ;
@@ -1372,6 +1400,19 @@ namespace engine
       }
       /// submit the read data
       readLen = cContext.submit( cb ) ;
+      /// verify page crc after data is filled into buf
+      if ( SDB_OK == rc && verifyCrc && readLen == record._dataLen )
+      {
+         UINT32 actualCrc = utilCrc32c( buf, readLen ) ;
+         if ( actualCrc != expectCrc )
+         {
+            PD_LOG( PDERROR, "Lob data page crc mismatch, piece[%s], page[%d], "
+                    "len[%u], expect[0x%08x], actual[0x%08x]",
+                    record.toString().c_str(), page, readLen,
+                    expectCrc, actualCrc ) ;
+            rc = SDB_DMS_CORRUPTED_EXTENT ;
+         }
+      }
       PD_TRACE_EXITRC( SDB__DMSSTORAGELOB_READ, rc ) ;
       return rc ;
    error:
@@ -1444,11 +1485,23 @@ namespace engine
       blk->_prevPageInBucket = DMS_LOB_INVALID_PAGEID ;
       blk->_nextPageInBucket = DMS_LOB_INVALID_PAGEID ;
       blk->setRemoved() ;
+      /// crc is (re)generated below when checksum is enabled, clear it
+      /// first so a reused page never carries a stale crc
+      blk->clearCrc() ;
+
+      /// A new page written from offset 0 holds the whole valid content
+      /// [0, _dataLen) in record._data, so the crc can be computed without
+      /// any extra read ( see design: only checksum fully written pages ).
+      if ( pmdGetOptionCB()->lobChecksumWriteOn() &&
+           0 == record._offset && NULL != record._data &&
+           record._dataLen > 0 )
+      {
+         blk->setCrc( utilCrc32c( record._data, record._dataLen ) ) ;
+      }
 
 #if defined (_DEBUG)
       {
-         UINT32 __hash = 0 ;
-         DMS_LOB_GET_HASH_FROM_BLK( blk, __hash ) ;
+         UINT32 __hash = _calcHash( *blk ) ;
          if ( __hash != record._hash )
          {
             dmsLobDataMapBlk memBlk ;
@@ -1850,8 +1903,7 @@ namespace engine
 
 #if defined (_DEBUG)
          {
-            UINT32 __hash = 0 ;
-            DMS_LOB_GET_HASH_FROM_BLK( blk, __hash ) ;
+            UINT32 __hash = _calcHash( *blk ) ;
             UINT32 testBucketNo = _getBucket( __hash ) ;
             if ( testBucketNo != bucketNumber )
             {
@@ -2161,6 +2213,10 @@ namespace engine
       BOOLEAN needFlushMME = FALSE ;
       UINT16 i = 0 ;
       dmsMBStatInfo *pMBStat = NULL ;
+
+      /// cache the lobm version ( like _pageSize ), so the hash hot path
+      /// does not need to read the mmap header
+      _hashVersion = getHeader()->_version ;
 
       i = _dmsData->_nextUsedMBSlot( 0 ) ;
       while ( DMS_INVALID_MBID != i )
@@ -2670,8 +2726,15 @@ namespace engine
       /// flush MME
       _dmsData->flushMME( TRUE ) ;
 
-      /// update the header
-      _dmsHeader->_version = DMS_LOB_CUR_VERSION ;
+      /// update the header. Only upgrade an old file to VERSION_2 ( which
+      /// still uses the djb2 hash ). Never relabel an old djb2 file as
+      /// VERSION_3 ( md5 ), and never downgrade a VERSION_3 file, otherwise
+      /// the bucket hash algorithm would mismatch the existing buckets.
+      if ( _dmsHeader->_version < DMS_LOB_VERSION_2 )
+      {
+         _dmsHeader->_version = DMS_LOB_VERSION_2 ;
+         _hashVersion = _dmsHeader->_version ;
+      }
       flushHeader( TRUE ) ;
 
    done:
@@ -2747,9 +2810,9 @@ namespace engine
             {
                dmsLobRecord record ;
                record.set( ( const bson::OID* )blk->_oid, blk->_sequence, 0,
-                           blk->_dataLen, NULL ) ;
+                           blk->_dataLen, NULL, hashType() ) ;
                /// add page to bucket
-               DMS_LOB_GET_HASH_FROM_BLK( blk, __hash ) ;
+               __hash = _calcHash( *blk ) ;
                testBucketNo = _getBucket( __hash ) ;
                rc = _push2Bucket( testBucketNo, current, NULL, *blk, &record ) ;
                if ( rc )
@@ -2789,10 +2852,13 @@ namespace engine
          ++current ;
       }
 
-      /// update the header
+      /// update the header. An old file rebuilt here was hashed with djb2,
+      /// so only upgrade it to VERSION_2 ( still djb2 ), never to VERSION_3
+      /// ( md5 ). A VERSION_3 file keeps its version and md5 hash.
       if ( _dmsHeader->_version <= DMS_LOB_VERSION_1 )
       {
-         _dmsHeader->_version = DMS_LOB_CUR_VERSION ;
+         _dmsHeader->_version = DMS_LOB_VERSION_2 ;
+         _hashVersion = _dmsHeader->_version ;
       }
       flushMeta( TRUE ) ;
 
@@ -2973,8 +3039,7 @@ namespace engine
       }
       else
       {
-         UINT32 __hash1 = 0 ;
-         DMS_LOB_GET_HASH_FROM_BLK( blk, __hash1 ) ;
+         UINT32 __hash1 = _calcHash( *blk ) ;
          bucketNumber = _getBucket( __hash1 ) ;
       }
 

--- a/SequoiaDB/engine/include/dmsDump.hpp
+++ b/SequoiaDB/engine/include/dmsDump.hpp
@@ -254,7 +254,8 @@ namespace engine
                                              UINT32 outSize,
                                              CHAR * addrPrefix,
                                              UINT32 options,
-                                             UINT32 pageSize);
+                                             UINT32 pageSize,
+                                             UTIL_LOB_HASH_TYPE hashType );
       private:
          static UINT32 _dumpExtentHeaderComm( const dmsExtent *extent,
                                               CHAR *outBuf, UINT32 outSize ) ;

--- a/SequoiaDB/engine/include/dmsLobDef.hpp
+++ b/SequoiaDB/engine/include/dmsLobDef.hpp
@@ -40,6 +40,7 @@
 #include "dms.hpp"
 #include "ossUtil.hpp"
 #include "pd.hpp"
+#include "utilLobID.hpp"
 #include "../bson/bson.hpp"
 
 namespace engine
@@ -50,7 +51,9 @@ namespace engine
    typedef SINT32 DMS_LOB_PAGEID ;
 
    #define DMS_LOB_VERSION_1                 1
-   #define DMS_LOB_CUR_VERSION               2
+   #define DMS_LOB_VERSION_2                 2
+   #define DMS_LOB_VERSION_3                 3
+   #define DMS_LOB_CUR_VERSION               DMS_LOB_VERSION_3
    #define DMS_LOB_META_SEQUENCE             0
 
    #define DMS_LOB_COMPLETE                  1
@@ -119,14 +122,14 @@ namespace engine
                 UINT32 sequence,
                 UINT32 offset,
                 UINT32 dataLen,
-                const CHAR *data )
+                const CHAR *data,
+                UTIL_LOB_HASH_TYPE hashType )
       {
          _oid = oid ;
          _sequence = sequence ;
          _offset = offset ;
-         _hash = ossHash( ( const BYTE * )_oid->getData(), 12,
-                          ( const BYTE * )( &_sequence ),
-                          sizeof( _sequence ) ) ;
+         _hash = utilLobHash( ( const BYTE * )_oid->getData(),
+                              _sequence, hashType ) ;
          _dataLen = dataLen ;
          _data = data ;
          return ;
@@ -259,6 +262,10 @@ namespace engine
    #define DMS_LOB_PAGE_FLAG_NEW             ( 1 )
    #define DMS_LOB_PAGE_FLAG_OLD             ( 0 )
 
+   /// data page crc state stored in _dmsLobDataMapBlk._crcFlag
+   #define DMS_LOB_PAGE_CRC_NONE            ( 0 )  /// no valid crc
+   #define DMS_LOB_PAGE_CRC_FULL           ( 1 )  /// crc covers [0, _dataLen)
+
    /*
       _dmsLobDataMapBlk define
    */
@@ -274,7 +281,9 @@ namespace engine
       UINT16         _mbID ;
       BYTE           _status ;
       BYTE           _newFlag ;
-      CHAR           _pad2[24];  /// sizeof( _dmsLobDataMapBlk ) == 64B
+      UINT32         _crc ;       /// data page crc32c, valid when _crcFlag FULL
+      BYTE           _crcFlag ;   /// DMS_LOB_PAGE_CRC_*
+      CHAR           _pad2[19];  /// sizeof( _dmsLobDataMapBlk ) == 64B
 
       _dmsLobDataMapBlk()
       {
@@ -295,6 +304,8 @@ namespace engine
          _mbID = DMS_INVALID_MBID ;
          _status = DMS_LOB_PAGE_REMOVED ;
          _newFlag = DMS_LOB_PAGE_FLAG_NEW ;
+         _crc = 0 ;
+         _crcFlag = DMS_LOB_PAGE_CRC_NONE ;
       }
 
       BOOLEAN isUndefined() const
@@ -327,6 +338,21 @@ namespace engine
          return _newFlag == DMS_LOB_PAGE_FLAG_NEW ? TRUE : FALSE ;
       }
       void setOld() { _newFlag = DMS_LOB_PAGE_FLAG_OLD ;}
+
+      BOOLEAN isCrcValid() const
+      {
+         return _crcFlag == DMS_LOB_PAGE_CRC_FULL ? TRUE : FALSE ;
+      }
+      void setCrc( UINT32 crc )
+      {
+         _crc = crc ;
+         _crcFlag = DMS_LOB_PAGE_CRC_FULL ;
+      }
+      void clearCrc()
+      {
+         _crc = 0 ;
+         _crcFlag = DMS_LOB_PAGE_CRC_NONE ;
+      }
 
       BOOLEAN equals( const BYTE *oid, UINT32 sequence ) const
       {

--- a/SequoiaDB/engine/include/dmsStorageLob.hpp
+++ b/SequoiaDB/engine/include/dmsStorageLob.hpp
@@ -94,7 +94,17 @@ namespace engine
       _dmsStorageLobData* getLobData() { return &_data ; }
       utilCacheUnit* getCacheUnit() { return _pCacheUnit ; }
 
-      static UINT32 getBucketID( const _dmsLobDataMapBlk &blk ) ;
+      /// lobm file version, cached from header ( like _pageSize ), used to
+      /// select the lob bucket hash algorithm without touching the mmap header
+      OSS_INLINE UINT32 hashVersion() const { return _hashVersion ; }
+      OSS_INLINE UTIL_LOB_HASH_TYPE hashType() const
+      {
+         return ( _hashVersion >= DMS_LOB_VERSION_3 ) ?
+                UTIL_LOB_HASH_MD5 : UTIL_LOB_HASH_DJB2 ;
+      }
+
+      static UINT32 getBucketID( const _dmsLobDataMapBlk &blk,
+                                 UTIL_LOB_HASH_TYPE hashType ) ;
 
    public:
       INT32 open( const CHAR *path,
@@ -280,6 +290,12 @@ namespace engine
          return &_vecBucketLacth[ bucketID % DMS_BUCKETS_LATCH_SIZE ] ;
       }
 
+      /// calculate the hash of a blk using this file's hash algorithm
+      OSS_INLINE UINT32 _calcHash( const _dmsLobDataMapBlk &blk ) const
+      {
+         return utilLobHash( blk._oid, blk._sequence, hashType() ) ;
+      }
+
       INT32 _push2Bucket( UINT32 bucket, DMS_LOB_PAGEID pageId,
                           pmdEDUCB *cb,
                           _dmsLobDataMapBlk &blk,
@@ -345,6 +361,8 @@ namespace engine
 
       BOOLEAN                       _isRename ;
       UINT32                        _dataSegmentSize ;
+      /// cache of header _version, not use header ( like _pageSize )
+      UINT32                        _hashVersion ;
    } ;
    typedef class _dmsStorageLob dmsStorageLob ;
 

--- a/SequoiaDB/engine/include/pmdOptionsMgr.hpp
+++ b/SequoiaDB/engine/include/pmdOptionsMgr.hpp
@@ -67,6 +67,12 @@ namespace engine
 
    #define PMD_NET_COMPRESSOR_MAX_STR_LENGTH   ( 6 )
 
+   /// lob data page checksum mask ( PMD_OPTION_LOB_DATA_CHECKSUM )
+   #define PMD_LOB_CHECKSUM_NONE       ( 0x00000000 )
+   #define PMD_LOB_CHECKSUM_WRITE      ( 0x00000001 )
+   #define PMD_LOB_CHECKSUM_READ       ( 0x00000002 )
+   #define PMD_LOB_CHECKSUM_DFT_STR    "write"
+
    enum PMD_CFG_STEP
    {
       PMD_CFG_STEP_INIT       = 0,           // initialize
@@ -652,6 +658,17 @@ namespace engine
          OSS_INLINE BOOLEAN isTraceOn() const { return _traceOn ; }
          OSS_INLINE UINT32 traceBuffSize() const { return _traceBufSz ; }
          OSS_INLINE BOOLEAN useDirectIOInLob() const { return _directIOInLob ; }
+         OSS_INLINE UINT32 lobChecksumMask() const { return _lobChecksumMask ; }
+         OSS_INLINE BOOLEAN lobChecksumWriteOn() const
+         {
+            return OSS_BIT_TEST( _lobChecksumMask, PMD_LOB_CHECKSUM_WRITE ) ?
+                   TRUE : FALSE ;
+         }
+         OSS_INLINE BOOLEAN lobChecksumReadOn() const
+         {
+            return OSS_BIT_TEST( _lobChecksumMask, PMD_LOB_CHECKSUM_READ ) ?
+                   TRUE : FALSE ;
+         }
          OSS_INLINE BOOLEAN sparseFile() const { return _sparseFile ; }
          OSS_INLINE UINT8 weight() const { return (UINT8)_weight ; }
          OSS_INLINE BOOLEAN authEnabled() const { return _auth ; }
@@ -802,6 +819,7 @@ namespace engine
          CHAR        _prefConstraint[ PMD_MAX_LONG_STR_LEN + 1 ] ;
          CHAR        _auditMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
          CHAR        _ftMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
+         CHAR        _lobChecksumMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
          CHAR        _memDebugMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
          CHAR        _monGroupMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
          CHAR        _serviceMaskStr[ PMD_MAX_LONG_STR_LEN + 1 ] ;
@@ -842,6 +860,7 @@ namespace engine
          INT32       _auditFileNum ;
          UINT32      _auditMask ;
          UINT32      _ftMask ;
+         UINT32      _lobChecksumMask ;
          UINT32      _ftConfirmPeriod ;
          UINT32      _ftConfirmRatio ;
          INT32       _ftLevel ;

--- a/SequoiaDB/engine/include/utilLobID.hpp
+++ b/SequoiaDB/engine/include/utilLobID.hpp
@@ -46,6 +46,31 @@ using namespace std ;
 namespace engine
 {
    /*
+      Lob bucket hash algorithm type. The caller ( dms ) maps the lobm file
+      version to one of these types, so that util does not depend on dms
+      version constants.
+   */
+   enum UTIL_LOB_HASH_TYPE
+   {
+      UTIL_LOB_HASH_DJB2 = 0,  /// legacy, for old lobm files
+      UTIL_LOB_HASH_MD5        /// md5 based, same as coord clsPartition
+   } ;
+
+   /*
+      Calculate the lob bucket hash from oid( 12 bytes ) and sequence.
+      UTIL_LOB_HASH_DJB2: keep the same result as the old ossHash algorithm.
+      UTIL_LOB_HASH_MD5 : md5( oid ++ sequence ), identical to clsPartition.
+   */
+   UINT32 utilLobHash( const BYTE *oid,
+                       UINT32 sequence,
+                       UTIL_LOB_HASH_TYPE hashType ) ;
+
+   /*
+      CRC32C ( Castagnoli ) checksum, used to verify lob data page validity.
+   */
+   UINT32 utilCrc32c( const void *data, UINT32 len ) ;
+
+   /*
       _utilLobID define
    */
 

--- a/SequoiaDB/engine/pmd/pmdOptionsMgr.cpp
+++ b/SequoiaDB/engine/pmd/pmdOptionsMgr.cpp
@@ -1952,6 +1952,7 @@ done:
       ossMemset( _krcbLobMetaPath, 0, OSS_MAX_PATHSIZE + 1 ) ;
       ossMemset( _auditMaskStr, 0, sizeof( _auditMaskStr ) ) ;
       ossMemset( _ftMaskStr, 0, sizeof( _ftMaskStr ) ) ;
+      ossMemset( _lobChecksumMaskStr, 0, sizeof( _lobChecksumMaskStr ) ) ;
       ossMemset( _memDebugMaskStr, 0, sizeof( _memDebugMaskStr ) ) ;
       ossMemset( _monGroupMaskStr, 0, sizeof( _monGroupMaskStr ) ) ;
       ossMemset( _serviceMaskStr, 0, sizeof( _serviceMaskStr ) ) ;
@@ -1993,6 +1994,7 @@ done:
       _auditFileNum        = 0 ;
       _auditMask           = 0 ;
       _ftMask              = PMD_FT_MASK_DFT ;
+      _lobChecksumMask     = PMD_LOB_CHECKSUM_WRITE ;
       _ftConfirmPeriod     = PMD_FT_CACL_INTERVAL_DFT ;
       _ftConfirmRatio      = PMD_FT_CACL_RATIO_DFT ;
       _ftLevel             = FT_LEVEL_SEMI ;
@@ -2195,6 +2197,10 @@ done:
       // --ftmask
       rdxString( pEX, PMD_OPTION_FT_MASK, _ftMaskStr, sizeof(_ftMaskStr),
                  FALSE, PMD_CFG_CHANGE_RUN, PMD_FT_MASK_DFT_STR ) ;
+      // --lobdatachecksum
+      rdxString( pEX, PMD_OPTION_LOB_DATA_CHECKSUM, _lobChecksumMaskStr,
+                 sizeof( _lobChecksumMaskStr ), FALSE, PMD_CFG_CHANGE_RUN,
+                 PMD_LOB_CHECKSUM_DFT_STR ) ;
       // --ftconfirmperiod
       rdxUInt( pEX, PMD_OPTION_FT_CONFIRM_PERIOD, _ftConfirmPeriod,
                FALSE, PMD_CFG_CHANGE_RUN, PMD_FT_CACL_INTERVAL_DFT ) ;
@@ -2835,6 +2841,58 @@ done:
       return getResult () ;
    }
 
+   /*
+      Parse lob data checksum mask string ( e.g. "write|read" ) into mask.
+      An empty string means checksum disabled. Return SDB_INVALIDARG on any
+      unknown token.
+   */
+   static INT32 pmdString2LobChecksumMask( const CHAR *pStr, UINT32 &mask )
+   {
+      INT32 rc = SDB_OK ;
+      mask = PMD_LOB_CHECKSUM_NONE ;
+
+      if ( NULL == pStr || 0 == pStr[ 0 ] )
+      {
+         goto done ;
+      }
+
+      {
+         ossPoolString str( pStr ) ;
+         ossPoolString::size_type begin = 0 ;
+         while ( begin < str.size() )
+         {
+            ossPoolString::size_type pos = str.find( '|', begin ) ;
+            ossPoolString token = ( ossPoolString::npos == pos ) ?
+                                  str.substr( begin ) :
+                                  str.substr( begin, pos - begin ) ;
+            if ( token == "write" )
+            {
+               mask |= PMD_LOB_CHECKSUM_WRITE ;
+            }
+            else if ( token == "read" )
+            {
+               mask |= PMD_LOB_CHECKSUM_READ ;
+            }
+            else if ( !token.empty() )
+            {
+               rc = SDB_INVALIDARG ;
+               goto error ;
+            }
+
+            if ( ossPoolString::npos == pos )
+            {
+               break ;
+            }
+            begin = pos + 1 ;
+         }
+      }
+
+   done:
+      return rc ;
+   error:
+      goto done ;
+   }
+
    INT32 _pmdOptionsMgr::postLoaded ( PMD_CFG_STEP step )
    {
       INT32 rc = SDB_OK ;
@@ -2924,6 +2982,18 @@ done:
                    << endl ;
          _ftMask = PMD_FT_MASK_DFT ;
          ossStrncpy( _ftMaskStr, PMD_FT_MASK_DFT_STR, sizeof( _ftMaskStr ) ) ;
+         _invalidConfNum++ ;
+      }
+
+      // lob data checksum mask check
+      if ( SDB_OK != pmdString2LobChecksumMask( _lobChecksumMaskStr,
+                                               _lobChecksumMask ) )
+      {
+         std::cerr << PMD_OPTION_LOB_DATA_CHECKSUM << " value error, use default"
+                   << endl ;
+         _lobChecksumMask = PMD_LOB_CHECKSUM_WRITE ;
+         ossStrncpy( _lobChecksumMaskStr, PMD_LOB_CHECKSUM_DFT_STR,
+                     sizeof( _lobChecksumMaskStr ) ) ;
          _invalidConfNum++ ;
       }
 

--- a/SequoiaDB/engine/rtn/rtnContextShdOfLob.cpp
+++ b/SequoiaDB/engine/rtn/rtnContextShdOfLob.cpp
@@ -714,7 +714,8 @@ namespace engine
          BOOLEAN withData = ( SDB_LOB_MODE_READ == _mode && !_reopened ) ?
                             TRUE : FALSE ;
 
-         record.set( &_oid, DMS_LOB_META_SEQUENCE, 0, len, NULL ) ;
+         record.set( &_oid, DMS_LOB_META_SEQUENCE, 0, len, NULL,
+                     _su->lob()->hashType() ) ;
 
          rc = _extendBuf( len * 2 ) ;
          if ( rc )
@@ -842,7 +843,8 @@ namespace engine
             UINT32 len = DMS_LOB_META_LENGTH ;
             dmsLobRecord record ;
 
-            record.set( &_oid, DMS_LOB_META_SEQUENCE, 0, len, NULL ) ;
+            record.set( &_oid, DMS_LOB_META_SEQUENCE, 0, len, NULL,
+                     _su->lob()->hashType() ) ;
 
             rc = _extendBuf( len ) ;
             if ( rc )

--- a/SequoiaDB/engine/rtn/rtnLob.cpp
+++ b/SequoiaDB/engine/rtn/rtnLob.cpp
@@ -972,7 +972,8 @@ namespace engine
          goto error ;
       }
 
-      record.set( &oid, sequence, offset, len, data ) ;
+      record.set( &oid, sequence, offset, len, data,
+                  lobEnv.getSU()->lob()->hashType() ) ;
       rc = lobEnv.getSU()->lob()->write( record, lobEnv.getMBContext(),
                                          cb, dpsCB ) ;
 
@@ -1021,7 +1022,8 @@ namespace engine
          goto error ;
       }
 
-      record.set( &oid, sequence, offset, len, data ) ;
+      record.set( &oid, sequence, offset, len, data,
+                  lobEnv.getSU()->lob()->hashType() ) ;
       rc = lobEnv.getSU()->lob()->writeOrUpdate( record, lobEnv.getMBContext(),
                                                  cb, dpsCB, hasUpdated ) ;
 
@@ -1159,7 +1161,8 @@ namespace engine
          goto error ;
       }
 
-      record.set( &oid, sequence, offset, len, np ) ;
+      record.set( &oid, sequence, offset, len, np,
+                  lobEnv.getSU()->lob()->hashType() ) ;
       rc = lobEnv.getSU()->lob()->read( record, lobEnv.getMBContext(), cb,
                                         data, read ) ;
       if ( SDB_OK != rc )
@@ -1199,7 +1202,8 @@ namespace engine
          goto error ;
       }
 
-      record.set( &oid, sequence, 0, 0, NULL ) ;
+      record.set( &oid, sequence, 0, 0, NULL,
+                  lobEnv.getSU()->lob()->hashType() ) ;
       rc = lobEnv.getSU()->lob()->remove( record, lobEnv.getMBContext(), cb,
                                           dpsCB, onlyRemoveNewPiece, pOldData ) ;
       if ( SDB_OK != rc )
@@ -1315,7 +1319,7 @@ namespace engine
       }
 
       record.set( &oid, sequence, offset,
-                  len, data ) ;
+                  len, data, lobEnv.getSU()->lob()->hashType() ) ;
 
       rc = lobEnv.getSU()->lob()->update( record, lobEnv.getMBContext(), cb,
                                           dpsCB ) ;

--- a/SequoiaDB/engine/rtn/rtnLobFetcher.cpp
+++ b/SequoiaDB/engine/rtn/rtnLobFetcher.cpp
@@ -211,7 +211,7 @@ namespace engine
          }
 
          record.set( &( page._oid ), page._sequence, 0,
-                     page._len, NULL ) ;
+                     page._len, NULL, _su->lob()->hashType() ) ;
          rc = _su->lob()->read( record, _mbContext,
                                 cb, mb->writePtr(), read ) ;
          if ( SDB_OK != rc )

--- a/SequoiaDB/engine/rtn/rtnLocalLobStream.cpp
+++ b/SequoiaDB/engine/rtn/rtnLocalLobStream.cpp
@@ -249,7 +249,8 @@ namespace engine
          goto error ;
       }
 
-      record.set( &getOID(), DMS_LOB_META_SEQUENCE, 0, len, NULL ) ;
+      record.set( &getOID(), DMS_LOB_META_SEQUENCE, 0, len, NULL,
+                  _su->lob()->hashType() ) ;
 
       /// read whole the meta page
       rc = _su->lob()->read( record, _mbContext, cb, buf, readLen ) ;
@@ -389,7 +390,8 @@ namespace engine
             goto error ;
          }
 
-         record.set( &getOID(), DMS_LOB_META_SEQUENCE, 0, len, NULL ) ;
+         record.set( &getOID(), DMS_LOB_META_SEQUENCE, 0, len, NULL,
+                  _su->lob()->hashType() ) ;
 
          rc = _su->lob()->read( record, _mbContext, cb, buf, readLen ) ;
          if ( SDB_OK == rc )
@@ -572,7 +574,8 @@ namespace engine
                   tuple.tuple.columns.sequence,
                   tuple.tuple.columns.offset,
                   tuple.tuple.columns.len,
-                  tuple.data ) ;
+                  tuple.data,
+                  _su->lob()->hashType() ) ;
 
       // write or update to dms
       if ( orUpdate )
@@ -653,7 +656,8 @@ namespace engine
       PD_RC_CHECK( rc, PDERROR, "Database is not writable, rc = %d", rc ) ;
 
       record.set( &getOID(), t.columns.sequence, t.columns.offset,
-                  t.columns.len, ( const CHAR * )tuple.data ) ;
+                  t.columns.len, ( const CHAR * )tuple.data,
+                  _su->lob()->hashType() ) ;
 
       if ( DMS_LOB_META_SEQUENCE == t.columns.sequence &&
            SDB_HAS_LOBWRITE_MODE(_getMode()) &&
@@ -898,7 +902,8 @@ namespace engine
                   tuple.tuple.columns.sequence,
                   tuple.tuple.columns.offset,
                   tuple.tuple.columns.len,
-                  tuple.data ) ;
+                  tuple.data,
+                  _su->lob()->hashType() ) ;
       rc = _su->lob()->read( record, _mbContext, cb,
                              buf, len ) ;
       if ( SDB_OK != rc )
@@ -930,7 +935,7 @@ namespace engine
       while ( 0 < num )
       {
          --num ;
-         piece.set( &getOID(), num, 0, 0, NULL ) ;
+         piece.set( &getOID(), num, 0, 0, NULL, _su->lob()->hashType() ) ;
          rc = _su->lob()->remove( piece, _mbContext, cb,
                                   _getDPSCB() ) ;
          if ( SDB_OK != rc )
@@ -1174,7 +1179,8 @@ namespace engine
                      itr->tuple.columns.sequence,
                      itr->tuple.columns.offset,
                      itr->tuple.columns.len,
-                     itr->data ) ;
+                     itr->data,
+                     _su->lob()->hashType() ) ;
          rc = _su->lob()->remove( record, _mbContext, cb,
                                   _getDPSCB() ) ;
          if ( SDB_OK != rc )

--- a/SequoiaDB/engine/tools/sdbinspt.cpp
+++ b/SequoiaDB/engine/tools/sdbinspt.cpp
@@ -80,6 +80,7 @@ namespace fs = boost::filesystem ;
 #define OPTION_NUMPAGE      "numpage"
 #define OPTION_SHOW_CONTENT "record"
 #define OPTION_ONLY_META    "meta"
+#define OPTION_CRCCHECK     "crccheck"
 #define OPTION_JUDGE_BALANCE "balance"
 #define OPTION_REPAIRE      "repaire"
 #define OPTION_RECOVER      "recover"
@@ -127,6 +128,7 @@ namespace fs = boost::filesystem ;
        ( COMMANDS_STRING(OPTION_NUMPAGE, ",n"), boost::program_options::value<SINT32>(), "number of pages, take effect when valid <pagestart>" ) \
        ( COMMANDS_STRING(OPTION_SHOW_CONTENT, ",p"), boost::program_options::value<string>(), "display data/index content (true/false), default: false" ) \
        ( OPTION_ONLY_META, boost::program_options::value<string>(), "inspect only meta(Header, SME, MME) (true/false), default:false" ) \
+       ( COMMANDS_STRING(OPTION_CRCCHECK, ",C"), boost::program_options::value<string>(), "verify lob data page crc when inspect lob, slower, default: false" ) \
        ( OPTION_MAX_FILESZ, boost::program_options::value<SINT32>(), "the max size (MB) for a output file, range:[10,524288], default: 500" ) \
        ( OPTION_FORCE, "force dump all invalid mb, delete list and index list and so on, default:false" )
 
@@ -495,6 +497,8 @@ namespace
     BOOLEAN gDumpLob                                     = FALSE;
     UINT32  gLobdPageSize                                = 0;
     UINT32  gLobmPageSize                                = 0;
+    /// lobm header version, decides the lob bucket hash algorithm
+    UINT32  gLobmVersion                                 = DMS_LOB_CUR_VERSION;
     UINT32  gSequence                                    = 0;
     BOOLEAN gExistLobs                                   = FALSE;
 
@@ -520,6 +524,7 @@ namespace
     BOOLEAN gInitMME                                     = FALSE ;
     BOOLEAN gShowRecordContent                           = FALSE ;
     BOOLEAN gOnlyMeta                                    = FALSE ;
+    BOOLEAN gCrcCheck                                    = FALSE ;
     BOOLEAN gForce                                       = FALSE ;
     BOOLEAN gReachEnd                                    = FALSE ;
     BOOLEAN gHitError                                    = FALSE ;
@@ -1369,6 +1374,10 @@ INT32 resolveArgument ( po::options_description &desc, INT32 argc, CHAR **argv )
    {
       ossStrToBoolean( vm[OPTION_ONLY_META].as<string>().c_str(), &gOnlyMeta ) ;
    }
+   if ( vm.count( OPTION_CRCCHECK ) )
+   {
+      ossStrToBoolean( vm[OPTION_CRCCHECK].as<string>().c_str(), &gCrcCheck ) ;
+   }
 
    /* deprecated
    if ( vm.count( OPTION_JUDGE_BALANCE) )
@@ -1695,6 +1704,13 @@ void clearBuffer ()
 }
 
 // inspect SU's header
+/// map the lobm header version to the lob bucket hash algorithm
+static UTIL_LOB_HASH_TYPE gLobHashType ()
+{
+   return ( gLobmVersion >= DMS_LOB_VERSION_3 ) ?
+          UTIL_LOB_HASH_MD5 : UTIL_LOB_HASH_DJB2 ;
+}
+
 INT32 inspectLobmHeader ( OSSFILE &file, INT64 fileSize, SINT32 &err )
 {
    INT32 rc       = SDB_OK ;
@@ -1709,6 +1725,9 @@ INT32 inspectLobmHeader ( OSSFILE &file, INT64 fileSize, SINT32 &err )
       ++err ;
       goto error ;
    }
+
+   /// remember the version to choose the bucket hash algorithm later
+   gLobmVersion = ( ( const dmsStorageUnitHeader * )headerBuffer )->_version ;
    // attempt to format, note if len is gBufferSize - 1, that means we write to
    // end of buffer, which represents the current buffer size is not sufficient,
    // then clearly we should attempt to realloc buffer and format again
@@ -3457,6 +3476,11 @@ void inspectCollectionLob( OSSFILE &lobmFile, UINT32 pageSize,
    dmsLobDataMapBlk blk ;
    MAP_CL_PAGES::iterator it ;
    MAP_PAGES::iterator itMap ;
+   /// page crc check counters
+   UINT64 crcPass       = 0 ;
+   UINT64 crcFail       = 0 ;
+   UINT64 crcSkip       = 0 ;
+   CHAR  *lobdCrcBuf    = NULL ;
 
    UINT64 beginTime = 0 ;
    UINT64 endTime = 0 ;
@@ -3507,6 +3531,54 @@ void inspectCollectionLob( OSSFILE &lobmFile, UINT32 pageSize,
             ++gMBStat._totalLobs ;
          }
 
+         /// verify the data page crc when the blk carries a full crc.
+         /// crc verification is opt-in ( --crccheck true ): it reads back
+         /// every data page and recomputes crc, which is much slower than a
+         /// plain inspect, so keep it off by default.
+         /// guard _dataLen against the page size: inspect may run on a
+         /// corrupt file, a bad _dataLen must not overflow the read buffer
+         /// ( such a blk is already flagged by inspectDmsLobDataMapBlk ).
+         if ( gCrcCheck && !gOnlyMeta && blk.isCrcValid() &&
+              blk._dataLen > 0 && blk._dataLen <= gLobdPageSize )
+         {
+            if ( NULL == lobdCrcBuf )
+            {
+               lobdCrcBuf = ( CHAR * )SDB_OSS_MALLOC( gLobdPageSize ) ;
+               if ( NULL == lobdCrcBuf )
+               {
+                  rc = SDB_OOM ;
+                  dumpPrintf( "*** Error: Failed to alloc lobd crc buffer" OSS_NEWLINE ) ;
+                  ++err ;
+                  goto error ;
+               }
+            }
+            rc = readData( &gLobdFile,
+                           DMS_HEADER_SZ + (INT64)gLobdPageSize * beginPageID,
+                           blk._dataLen, lobdCrcBuf, FALSE, "lobd crc" ) ;
+            if ( rc )
+            {
+               ++err ;
+               goto error ;
+            }
+            UINT32 actualCrc = utilCrc32c( lobdCrcBuf, blk._dataLen ) ;
+            if ( actualCrc == blk._crc )
+            {
+               ++crcPass ;
+            }
+            else
+            {
+               ++crcFail ;
+               ++err ;
+               dumpPrintf( "*** Error: Lob data page(%d) crc mismatch, "
+                           "expect[0x%08x] actual[0x%08x] dataLen[%u]" OSS_NEWLINE,
+                           beginPageID, blk._crc, actualCrc, blk._dataLen ) ;
+            }
+         }
+         else if ( gCrcCheck && !gOnlyMeta )
+         {
+            ++crcSkip ;
+         }
+
          if ( gOnlyMeta )
          {
             ++beginPageID ;
@@ -3547,6 +3619,11 @@ void inspectCollectionLob( OSSFILE &lobmFile, UINT32 pageSize,
    }
 
 done:
+   if ( NULL != lobdCrcBuf )
+   {
+      SDB_OSS_FREE( lobdCrcBuf ) ;
+      lobdCrcBuf = NULL ;
+   }
    endTime = ossGetCurrentMilliseconds() ;
    if ( endTime > beginTime )
    {
@@ -3578,12 +3655,28 @@ done:
                   "    Total Lob Pages   : %u" OSS_NEWLINE
                   "    Total Lob Size    : %llu" OSS_NEWLINE
                   "    Lob Usage Rate    : %.2f%%" OSS_NEWLINE
-                  "    Total Lobs        : %llu" OSS_NEWLINE OSS_NEWLINE,
+                  "    Total Lobs        : %llu" OSS_NEWLINE,
                   clId,
                   gMBStat._totalLobPages,
                   gMBStat._totalLobSize,
                   lobUsageRate * 100,
                   gMBStat._totalLobs ) ;
+
+      if ( !gOnlyMeta )
+      {
+         if ( gCrcCheck )
+         {
+            dumpPrintf( "    Page CRC Check    : Pass %llu, Fail %llu, "
+                        "NoCRC %llu" OSS_NEWLINE,
+                        crcPass, crcFail, crcSkip ) ;
+         }
+         else
+         {
+            dumpPrintf( "    Page CRC Check    : skipped "
+                        "(use --crccheck true)" OSS_NEWLINE ) ;
+         }
+      }
+      dumpPrintf( OSS_NEWLINE ) ;
    }
    else
    {
@@ -4353,10 +4446,8 @@ error :
 #define DMS_LOB_GET_HASH_FROM_BLK( blk, hash )\
         do\
         {\
-           const BYTE *d1 = (blk)->_oid ;\
-           const BYTE *d2 = ( const BYTE * )( &( (blk)->_sequence ) ) ;\
-           (hash) = ossHash( d1, sizeof( (blk)->_oid ),\
-                             d2, sizeof( (blk)->_sequence ) ) ;\
+           (hash) = utilLobHash( (blk)->_oid, (blk)->_sequence,\
+                                 gLobHashType() ) ;\
         } while( FALSE )
 
 static dmsLobDataMapBlk* _getLobBlk( ossMmapFile &lobmMapFile, UINT32 pageID )
@@ -4713,7 +4804,7 @@ void recoverCollectionLob( OSSFILE &lobmFile, UINT32 pageSize,
             {
                dmsLobRecord record ;
                record.set( ( const bson::OID* )pBlk->_oid, pBlk->_sequence, 0,
-                           pBlk->_dataLen, NULL ) ;
+                           pBlk->_dataLen, NULL, gLobHashType() ) ;
                /// add page to bucket
                DMS_LOB_GET_HASH_FROM_BLK( pBlk, __hash ) ;
                testBucketNo = _getLobBucketByHash( __hash ) ;
@@ -5177,7 +5268,7 @@ INT32 dumpLobmMeta( OSSFILE &file, UINT32 pageId, CHAR *pageBuf, UINT32 pageSize
 retry_dmsLobDataMapBlk:
 
    len = dmsDump::dumpDmsLobDataMapBlk( pageId, blk, gBuffer, gBufferSize, NULL,
-                                        gDumpType, pageSize ) ;
+                                        gDumpType, pageSize, gLobHashType() ) ;
    if ( (UINT32)len >= gBufferSize -1 )
    {
       // if our buffer is not large enough, let's allocate more memory and
@@ -5714,7 +5805,7 @@ INT32 parseLobmBMEAndPages( OSSFILE &lobmFile, UINT32 pageSize, UINT32 maxPages,
       nextPageID = blk._nextPageInBucket ;
 
       /// calc hash code and bucket id
-      bucketID = dmsStorageLob::getBucketID(  blk ) ;
+      bucketID = dmsStorageLob::getBucketID(  blk, gLobHashType() ) ;
 
       if ( DMS_LOB_INVALID_PAGEID == prevPageID )
       {

--- a/SequoiaDB/engine/util/utilLobID.cpp
+++ b/SequoiaDB/engine/util/utilLobID.cpp
@@ -35,6 +35,9 @@
 #include "pd.hpp"
 #include "pdTrace.hpp"
 #include "utilLobID.hpp"
+#include "ossUtil.hpp"
+#include "../bson/lib/md5.hpp"
+#include "../bson/lib/md5.h"
 
 #include <sstream>
 
@@ -42,6 +45,88 @@ using namespace std ;
 
 namespace engine
 {
+   /// CRC32C ( Castagnoli ) reflected polynomial
+   #define UTIL_CRC32C_POLY   ( 0x82F63B78 )
+
+   /*
+      CRC32C lookup table. Wrapped in a type with a non-trivial constructor
+      so that the function local static below gets C++11's thread-safe
+      one-time initialization ( a hand-rolled bool guard would race ).
+   */
+   struct _utilCrc32cTable
+   {
+      UINT32 _t[ 256 ] ;
+      _utilCrc32cTable()
+      {
+         for ( UINT32 i = 0 ; i < 256 ; ++i )
+         {
+            UINT32 crc = i ;
+            for ( UINT32 j = 0 ; j < 8 ; ++j )
+            {
+               crc = ( crc & 1 ) ? ( ( crc >> 1 ) ^ UTIL_CRC32C_POLY )
+                                 : ( crc >> 1 ) ;
+            }
+            _t[ i ] = crc ;
+         }
+      }
+   } ;
+
+   static const UINT32* utilGetCrc32cTable()
+   {
+      /// C++11: initialization of a local static is thread-safe
+      static const _utilCrc32cTable s_table ;
+      return s_table._t ;
+   }
+
+   UINT32 utilLobHash( const BYTE *oid,
+                       UINT32 sequence,
+                       UTIL_LOB_HASH_TYPE hashType )
+   {
+      UINT32 hashValue = 0 ;
+
+      if ( UTIL_LOB_HASH_MD5 == hashType )
+      {
+         md5_state_t st ;
+         md5::md5digest digest ;
+         UINT32 i = 0 ;
+
+         md5_init( &st ) ;
+         md5_append( &st, ( const md5_byte_t * )oid, UTIL_LOBID_ARRAY_LEN ) ;
+         md5_append( &st, ( const md5_byte_t * )( &sequence ),
+                     sizeof( sequence ) ) ;
+         md5_finish( &st, digest ) ;
+
+         /// take digest[1..4], same as clsPartition
+         while ( i++ < 4 )
+         {
+            hashValue |= ( ( UINT32 )digest[ i ] << ( 32 - 8 * i ) ) ;
+         }
+      }
+      else
+      {
+         /// legacy djb2, keep the same result as the old
+         /// DMS_LOB_GET_HASH_FROM_BLK macro
+         hashValue = ossHash( oid, UTIL_LOBID_ARRAY_LEN,
+                              ( const BYTE * )( &sequence ),
+                              sizeof( sequence ) ) ;
+      }
+
+      return hashValue ;
+   }
+
+   UINT32 utilCrc32c( const void *data, UINT32 len )
+   {
+      const UINT32 *table = utilGetCrc32cTable() ;
+      const BYTE *p = ( const BYTE * )data ;
+      UINT32 crc = 0xFFFFFFFF ;
+
+      for ( UINT32 i = 0 ; i < len ; ++i )
+      {
+         crc = table[ ( crc ^ p[ i ] ) & 0xFF ] ^ ( crc >> 8 ) ;
+      }
+
+      return crc ^ 0xFFFFFFFF ;
+   }
    // number is Odd or not in one byte
    INT32 _utilLobID::_isOddArray[256] = {
       0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,

--- a/design_doc/LOB_hash_crc_优化设计.md
+++ b/design_doc/LOB_hash_crc_优化设计.md
@@ -1,0 +1,371 @@
+# LOB 桶均衡性(hash)与数据页 CRC 校验 优化设计
+
+> 适用范围: 数据节点 LOB 存储(`.lobm` / `.lobd`)。
+> 目标:
+> - 问题 1:改进 LOB 桶 hash 算法,消除桶极不均衡(inspect 报告 Variance / Max Depth 偏大)。
+> - 问题 2:为 LOB 数据页(lobd)增加 CRC 校验,检测数据有效性。
+> 开发约束:编译零告警;最小改动;放置在合理模块、遵循既有命名与编码风格;测试用例写入 `testcase_new`,`./updateAll.sh` 一键编译运行。
+
+---
+
+## 0. 架构总览
+
+### 0.1 lobm / lobd 文件结构与对应关系
+
+```
+            lobm ( .lobm 元数据/桶 )                       lobd ( .lobd 数据 )
+   +------------------------------------+          +----------------------------+
+   | Header(64K)  _version / _pageSize  |          | Header(64K)                |
+   +------------------------------------+          +----------------------------+
+   | SME  空间位图(free/allocated)       |          | data page 0 (piece bytes)  |
+   +------------------------------------+          | data page 1                |
+   | BME  INT32 _buckets[16M] 桶链头      |---+      | ...                        |
+   +------------------------------------+   |      | data page N                |
+   | blk#0  _dmsLobDataMapBlk (64B)      |   |      +----------------------------+
+   | blk#1  {oid,seq,dataLen,            |   |          ^  page#N 一一对应 blk#N
+   | blk#N   prev/next, status,          |<--+----------+
+   |         crc,crcFlag}                |   桶链: _prevPageInBucket/_nextPageInBucket
+   +------------------------------------+
+```
+
+- **分片**:一个 LOB 按 lobd 页大小切成 piece;`sequence=0` 为 meta 页(合并首段数据),`1,2,…` 为后续整页。
+- **写桶**:`bucket = hash(oid,seq) & (2^24-1)`;`BME[bucket]` 指向一条 blk 双向链,`_find/_push2Bucket` 顺链操作。
+- **写页**:数据写入 lobd 第 N 页;`blk#N` 记录该页的 oid/seq/长度/链指针(本设计再加 crc)。
+
+### 0.2 本设计新增/改动点全景
+
+```mermaid
+flowchart LR
+  subgraph W[写路径]
+    A[rtn set oid,seq,hashType] --> B[dms write/update]
+    B --> C[_fillPage / _updateWithPage]
+    C --> D{{hash: utilLobHash by version}}
+    C --> E{{crc: utilCrc32c if writeOn & full-page}}
+  end
+  subgraph R[读路径]
+    F[rtn read whole page] --> G[dms read]
+    G --> H{{crc verify if readOn & crcFlag=FULL}}
+  end
+  subgraph T[离线]
+    I[sdbinspt --dumplob] --> J{{按版本选 hash 报告桶均衡性}}
+    I --> K{{Page CRC Check 报告}}
+  end
+```
+
+### 0.3 改动模块与文件一览
+
+| 模块 | 文件 | 改动摘要 |
+|---|---|---|
+| util | `include/utilLobID.hpp`,`util/utilLobID.cpp` | 新增 `utilLobHash`(djb2/md5)、`utilCrc32c`(CRC32C) |
+| dms | `include/dmsLobDef.hpp` | 版本常量;`set()` 传 hashType;blk 增 `_crc/_crcFlag`(64B) |
+| dms | `include/dmsStorageLob.hpp` | `_hashVersion` 缓存;`hashType()`/`_calcHash`;`getBucketID` 加参 |
+| dms | `dms/dmsStorageLob.cpp` | 版本缓存/迁移;hash 统一;CRC 生成(写)/校验(读) |
+| dms | `include/dmsDump.hpp`,`dms/dmsDump.cpp` | `dumpDmsLobDataMapBlk`/`getBucketID` 传 hashType |
+| rtn | `rtn/rtnLob.cpp` 等 4 文件 | `set()` 调用点传 `su->lob()->hashType()` |
+| pmd | `misc/autogen/optlist.xml`,`pmd/pmdOptionsMgr.*` | 节点参数 `lobdatachecksum`(mask,在线生效) |
+| tools | `tools/sdbinspt.cpp` | 按版本选 hash;Page CRC Check 报告 |
+| test | `testcase_new/story/js/lob/lob_*_6000x.js` | 3 个功能用例 |
+
+---
+
+## 1. 现状回顾(与本设计相关部分)
+
+- 每个集合 LOB = `.lobm`(元数据/桶) + `.lobd`(数据),由 `_dmsStorageLob` 管理
+  ([SequoiaDB/engine/include/dmsStorageLob.hpp](SequoiaDB/engine/include/dmsStorageLob.hpp))。
+- `.lobm` 数据区每页是 64B 的 `_dmsLobDataMapBlk`,描述对应 lobd 页并组成桶链
+  ([dmsLobDef.hpp:265](SequoiaDB/engine/include/dmsLobDef.hpp))。
+- 桶 hash = djb2 `ossHash(oid[12], sequence[4])`(宏 `DMS_LOB_GET_HASH_FROM_BLK`,
+  [dmsStorageLob.cpp:61](SequoiaDB/engine/dms/dmsStorageLob.cpp));桶号 = `hash & (2^24-1)`
+  (`_getBucket`,[dmsStorageLob.hpp:273](SequoiaDB/engine/include/dmsStorageLob.hpp))。
+- `record._hash` 在 rtn 层 `_dmsLobRecord::set()` 计算([dmsLobDef.hpp:118](SequoiaDB/engine/include/dmsLobDef.hpp));
+  dms 内部(`_fillPage/_find/_push2Bucket/rebuildBME`)用宏从 blk 重算,二者必须一致。
+- **备机回放不使用日志里的 hash**:DPS 日志虽含 `DPS_LOG_LOB_HASH`,但 `clsReplayer` 解析后该值被丢弃
+  ([clsReplayer.cpp:456](SequoiaDB/engine/cls/clsReplayer.cpp)),实际调用 `rtnWriteLob(...)`
+  ([clsReplayer.cpp:1578](SequoiaDB/engine/cls/clsReplayer.cpp)) → 内部 `record.set()` **本机重算**。
+  故主备各自本机计算,依赖的是"主备 lobm 文件版本一致",与 DPS hash 无关。
+- 注意:`clsReplayer::_calcLobBucketID` 里的 `BSON_HASHER::hash(oid+seq)`
+  ([clsReplayer.cpp:514](SequoiaDB/engine/cls/clsReplayer.cpp))是**回放并行分发桶**,与存储桶无关,**不得改动**。
+- coord/catalog 侧已有 `clsPartition(oid, sequence, partitionBit)`,对 **oid[12]+sequence[4] 做 MD5**
+  ([clsCatalogAgent.cpp:4982](SequoiaDB/engine/cls/clsCatalogAgent.cpp));`sizeof(bson::OID)==12`,输入与 dms 桶 hash 完全一致。
+- inspect(`sdbinspt --dumplob`)遍历所有页统计桶深度,输出均衡性报告(Min/Max/Average Depth、
+  Variance、深度直方图,[sdbinspt.cpp:6024](SequoiaDB/engine/tools/sdbinspt.cpp))。
+- 头部字段有对象缓存范式:`_pageSize/_lobPageSize` 为「cache, not use header」成员,open 时从
+  mmap 头拷入([dmsStorageBase.hpp:733](SequoiaDB/engine/include/dmsStorageBase.hpp)、[dmsStorageBase.cpp:1829](SequoiaDB/engine/dms/dmsStorageBase.cpp))。
+- 节点配置 mask 字符串范式:`--auditmask` / `--ftmask`,`rdxString(..., PMD_CFG_CHANGE_RUN, dft)`
+  运行时可改([pmdOptionsMgr.cpp:2193](SequoiaDB/engine/pmd/pmdOptionsMgr.cpp))。
+
+---
+
+## 2. 问题 1:LOB 桶 hash 优化
+
+### 2.1 根因
+桶号取 djb2 结果的低 24 位,而 djb2 低位雪崩性差;LOB OID 高度结构化(时间戳近常量、oddCheck 低熵、
+id 常量、serial 自增),sequence 为小整数 → hash 落点呈固定步长等差聚集 → 少数桶链极长、多数桶空,
+表现为 inspect Variance / Max Depth 偏大。桶链是遍历式 find/insert/remove,链长直接拖慢 LOB 读写。
+
+### 2.2 关键事实(决定改造代价低)
+blk **不持久化 hash**,桶归属由 hash 函数运行时决定。改 hash 不需迁移任何存量 hash,只需保证
+**同一文件始终用同一算法**。故:老文件用老算法、新文件用新算法,以 **lobm 文件版本号**区分。
+
+### 2.3 设计
+
+**(a) 版本区分 —— 复用已有 `_version`,不动通用头**
+- `_dmsStorageUnitHeader` 为三种 SU 共用,不新增字段;复用已有 `_version`。
+- lobm 版本升级:`DMS_LOB_VERSION_3 = 3`;`DMS_LOB_CUR_VERSION = 3`;`_curVersion()` 返回 3。
+- 新算法门控:`version >= 3` 用 MD5,`version <= 2` 用 djb2。
+- 旧二进制 `_checkVersion`(`_version > _curVersion()` 报错)天然拒绝打开 v3 文件,作为安全边界。
+
+**(b) 新算法 —— 复用 coord 的 MD5,抽公共函数**
+- 新增公共函数(util 模块已依赖 bson md5):
+  ```cpp
+  // 声明: SequoiaDB/engine/include/utilLobID.hpp
+  // 实现: SequoiaDB/engine/util/utilLobID.cpp
+  enum UTIL_LOB_HASH_TYPE { UTIL_LOB_HASH_DJB2 = 0, UTIL_LOB_HASH_MD5 } ;
+  UINT32 utilLobHash( const BYTE *oid, UINT32 sequence,
+                      UTIL_LOB_HASH_TYPE hashType ) ;
+  ```
+  用 **enum 而非版本号**入参,避免 util 依赖 dms 的版本常量;由 dms 的 `hashType()` 做映射。
+
+  **版本 → 算法 → 桶号 映射表**
+
+  | lobm `_version` | `hashType()` | 算法 | 桶号 |
+  |---|---|---|---|
+  | ≤ 2(老文件) | `UTIL_LOB_HASH_DJB2` | djb2 `ossHash(oid,12,&seq,4)` | `hash & (2^24-1)` |
+  | = 3(新文件) | `UTIL_LOB_HASH_MD5` | MD5(oid12‖seq4) 取 digest[1..4] 拼 32 位(同 `clsPartition`) | `hash & (2^24-1)` |
+
+- 桶号 `_getBucket` 不改(MD5 各 bit 均匀,取低位即可)。
+- 成本:piece 为页大小(KB 级),对 16 字节做一次 MD5 相对数据 IO 可忽略。
+- `clsPartition` 本期**不改**(避免影响分区路由);其算法与 `utilLobHash(MD5)` 等价,概念已统一。
+
+**版本赋值/迁移(关键:不误标、不降级)**
+
+```mermaid
+flowchart TD
+  C[新建 CS] -->|_initHeader = _curVersion=3| V3[version=3 → MD5]
+  O1[打开老文件 v1] --> M{_calcCount / rebuildBME}
+  M -->|version < 2 才升到 2| V2[version=2 → djb2]
+  O2[打开老文件 v2] --> KEEP2[保持 v2 → djb2]
+  O3[打开新文件 v3] --> KEEP3[保持 v3 → MD5, 不降级]
+```
+> 迁移路径只把 `v1→v2`(同为 djb2),**绝不**把老文件升到 v3,也**绝不**把 v3 降级,保证桶算法与既有桶一致。
+
+**(c) 版本对象缓存(仿 `_pageSize`)**
+- `_dmsStorageLob` 新增成员 `UINT32 _hashVersion ;`(cache, not use header)。
+- 填充:`_dmsStorageLob::_onOpened()`([dmsStorageLob.cpp:2159](SequoiaDB/engine/dms/dmsStorageLob.cpp))
+  中 `_hashVersion = getHeader()->_version ;`。
+- 刷新:凡改写 `_dmsHeader->_version` 的迁移路径同步更新缓存 ——
+  `rebuildBME`([:2795](SequoiaDB/engine/dms/dmsStorageLob.cpp))、`_calcCount`([:2674](SequoiaDB/engine/dms/dmsStorageLob.cpp))。
+- hash 热路径只读 `_hashVersion` 成员,**不访问 mmap 头**。
+
+**(d) `set()` 传版本,内外统一**
+- `_dmsLobRecord::set(oid, sequence, offset, dataLen, data, UINT32 hashVer)`:内部
+  `_hash = utilLobHash(oid, sequence, hashVer)`。
+- 调用处均持 su:`rtnWriteLob2`([rtnLob.cpp:975](SequoiaDB/engine/rtn/rtnLob.cpp))、fetcher
+  ([rtnLobFetcher.cpp:213](SequoiaDB/engine/rtn/rtnLobFetcher.cpp))等传
+  `su->lob()->hashVersion()`(新增内联 getter 返回 `_hashVersion`)。
+- dms 内部宏 `DMS_LOB_GET_HASH_FROM_BLK` 改为成员 `_calcHash(oid,seq)`(读 `_hashVersion`),
+  替换 `_fillPage/_find/_push2Bucket/rebuildBME` 及 DEBUG 断言处的所有重算点。
+- 静态 `getBucketID(blk)`([:127](SequoiaDB/engine/dms/dmsStorageLob.cpp))增 `hashVer` 入参,dump/inspect
+  由读到的头版本传入。
+
+**(e) 备机一致性(修正:回放不用 DPS hash)**
+- 备机回放经 `rtnWriteLob → record.set(..., su->lob()->hashVersion())` **本机重算 hash**,
+  不使用 DPS 日志里的 hash 值。因此**无需改动 DPS 模块**(`dpsOp2Record` / 日志 `_hash` 字段保持不变,
+  仅为兼容/日志用途,继续被回放忽略)。
+- 一致性充要条件:**主备 lobm 文件版本一致**。v3 文件只由新版本二进制创建/打开,建议
+  **v3 门控在集群升级提交后**创建的 CS 才启用,升级过程中新建 CS 仍用 v2,避免主备版本(算法)不一致。
+- `clsReplayer::_calcLobBucketID` 的并行分发桶 hash 与存储桶无关,**不改动**。
+
+**(f) inspect**
+- `inspectBME` 依据读到的头版本选择 `utilLobHash` 版本重算桶号,报告即反映新分布(改善验证工具)。
+
+### 2.4 存量重平衡(可选,不在本期强制)
+`rebuildBME` 已遍历全部页按 hash 重建桶链。可选提供 repair 动作:改写头版本→3 后用新算法
+`rebuildBME` 对老热点 CS 一次性重平衡。默认不动老 CS(满足"老 CS 用老算法")。
+
+---
+
+## 3. 问题 2:LOB 数据页 CRC 校验
+
+### 3.1 存储位置
+存进 lobm 的 `_dmsLobDataMapBlk._pad2[24]`(当前纯 padding):
+```cpp
+// 保持 struct 64B 不变
+UINT32 _crc ;       // lobd 数据页校验值(覆盖 [0, dataLen))
+UINT8  _crcFlag ;   // 0=NONE(无有效CRC) 1=FULL
+CHAR   _pad2[ 24 - sizeof(UINT32) - sizeof(UINT8) ] ; // = _pad2[19]
+```
+优点:校验值与数据分文件存放(检出 lobd 位翻转/半写);不改 lobd 页布局、与页大小无关;零迁移
+(旧页天然 `_crcFlag=0`);写入点天然在 `_fillPage`(现正好 `ossMemset(_pad2,0)`,[dmsStorageLob.cpp:1440](SequoiaDB/engine/dms/dmsStorageLob.cpp))。
+inspect `inspectDmsLobDataMapBlk` 仅校验 `_status/_dataLen`,不校验 pad2,无冲突。
+
+CRC 算法:CRC32C(优先硬件指令,退表法)或直接 `thirdparty/boost/boost/crc.hpp`。新增
+`utilCrc32c(const void*, UINT32)`(util 模块)。
+
+### 3.2 只对"全写页"生成(无 RMW)
+用独立 `_crcFlag`(不复用 `_newFlag`,后者语义是"改过没"):
+- `_fillPage` 新页整段写、或 `_updateWithPage` 中 `offset==0 && dataLen>=旧 blkLen`(整页覆盖/从 0 增长)
+  → 手里有整页有效内容 → 算 CRC 覆盖 `[0,dataLen)`,`_crcFlag=FULL`。
+- 真正子区间原地更新(offset>0 且不覆盖)→ `_crcFlag=NONE`,读侧跳过。
+- **写路径零额外 IO**。
+- `rebuildBME` **不读 lobd、不校验 CRC**(仅重建桶链),符合现状。
+
+**写路径 CRC 生成决策表**(`writeOn = lobChecksumWriteOn()`)
+
+| 场景 | writeOn | offset | 覆盖范围 | 结果 |
+|---|---|---|---|---|
+| 新页整段写 `_fillPage` | 是 | 0 | [0,dataLen) 全在 record._data | `setCrc`,`_crcFlag=FULL` |
+| 更新-整页覆盖 `_updateWithPage` | 是 | 0 | `dataLen ≥ orgBlkLen` | `setCrc`,`_crcFlag=FULL` |
+| 更新-子区间 `_updateWithPage` | 任意 | >0 或不覆盖 | 部分 | `clearCrc`,`_crcFlag=NONE`(防陈旧) |
+| 关闭 | 否 | — | — | 新页 NONE;更新一律 `clearCrc` |
+
+> `_crcFlag` 状态机:`NONE --整页写(writeOn)--> FULL`;`FULL --任意部分更新--> NONE`。永不残留陈旧 CRC。
+
+**读路径 CRC 校验流程**(`readOn = lobChecksumReadOn()`,校验点在 `read()`)
+
+```mermaid
+flowchart TD
+  S[read record] --> A{readOn 且 offset==0?}
+  A -- 否 --> RD[正常读, 不校验]
+  A -- 是 --> B[mb锁下取 blk]
+  B --> C{crcFlag==FULL 且 len==blk._dataLen?}
+  C -- 否 --> RD
+  C -- 是 --> D[记 expectCrc, 读数据]
+  D --> E[submit 填充 buf]
+  E --> F{utilCrc32c buf == expectCrc?}
+  F -- 是 --> OK[返回数据]
+  F -- 否 --> ERR[SDB_DMS_CORRUPTED_EXTENT + PD_LOG]
+```
+
+### 3.3 开关:节点配置参数(mask,经 optlist.xml 生成)
+仿 `--auditmask`,新增运行时可改参数。**参数定义在 `misc/autogen/optlist.xml` 新增 `<opt>`**
+(宏 `PMD_OPTION_LOB_DATA_CHECKSUM` 由构建自动生成,**不手写宏**),格式参照 `PMD_OPTION_AUDIT_MASK`
+([optlist.xml:415](misc/autogen/optlist.xml)):
+```xml
+<opt>
+  <name>PMD_OPTION_LOB_DATA_CHECKSUM</name>
+  <long>lobdatachecksum</long>
+  <description><en>LOB data page checksum mask, values: write,read; use '|' to join; default: write</en>
+                <cn>LOB 数据页校验掩码,取值:write,read,'|'连接;默认 write</cn></description>
+  <reloadable><en>Take effect immediately</en><cn>在线生效</cn></reloadable>
+  <default>write</default>
+  <typeofweb>str</typeofweb>
+</opt>
+```
+- 值 mask:`"write"`(默认)/`"read"`/`"write|read"`/`""`。`write` 位=全写页生成 CRC;`read` 位=整页读时校验。
+- pmdOptionsMgr 侧:用生成的宏 `rdxString(pEX, PMD_OPTION_LOB_DATA_CHECKSUM, _lobChecksumMaskStr,
+  sizeof(_lobChecksumMaskStr), FALSE, PMD_CFG_CHANGE_RUN, "write")`([pmdOptionsMgr.cpp:2193](SequoiaDB/engine/pmd/pmdOptionsMgr.cpp) 附近),
+  解析成 `UINT32 _lobChecksumMask`,提供 `lobChecksumWriteOn()/lobChecksumReadOn()`。
+- 说明(如实):节点级 ⇒ per-node,主备 CRC 存在性可能不同;但每页有 `_crcFlag`,校验仅在 `FULL` 时进行,
+  天然跳过缺失页;CRC 定位为本地数据有效性体检,不要求跨副本一致。不区分集合(相对集合属性的取舍)。
+
+### 3.4 校验点
+> 实现修正:`readPage`([dmsStorageLob.cpp](SequoiaDB/engine/dms/dmsStorageLob.cpp))只读 lobm blk、不读 lobd 数据,
+> 无法在其中校验整页 crc。真正的整页数据读发生在 `read()`(fetcher 以 offset=0、len=整页调用),
+> 故校验点落在 **`read()`**:当 `read` 位开启且为整页读(offset==0 且 len==页数据长)且 blk `_crcFlag==FULL`
+> 时,在 mb 锁下捕获 `expectCrc`,submit 填充 buf 后 `utilCrc32c` 比对,不符返回错误并 PD_LOG 定位;
+> 子区间读不校验。inspect 侧在 `inspectCollectionLob` 逐页读 lobd 校验并输出 "Page CRC Check"。
+>
+> 错误码:**复用现有 `SDB_DMS_CORRUPTED_EXTENT`**("DMS extent is corrupted",lob 数据页即一个 dms extent),
+> 避免向 `rclist.xml` 追加新码带来的跨分支重编号风险。如需专用码,可按 `rclist.xml` 末尾追加 +
+> `SDB_ERROR_RESERVED_NNN` 对齐的机制新增(本期未做)。
+- inspect:CRC 校验**由参数 `--crccheck`(短 `-C`)控制,默认关闭**。因校验需逐页回读 lobd 数据并重算 CRC,
+  比常规 inspect 慢很多,故做成显式开启:`sdbdmsdump -a inspect -b true -C true`。
+  - 开启时:遍历 `_crcFlag==FULL` 的页校验,报告 "Page CRC Check : Pass/Fail/NoCRC";每个失配页额外打印
+    `expect/actual/dataLen` 明细,便于区分"数据损坏"与"CRC 字段损坏"。
+  - 关闭时(默认):报告 "Page CRC Check : skipped (use --crccheck true)",不产生额外 IO。
+  与桶均衡性报告并列输出([sdbinspt.cpp](SequoiaDB/engine/tools/sdbinspt.cpp) inspectBME/inspect 数据页处)。
+- dump:`dumpDmsLobDataMapBlk`([dmsDump.cpp](SequoiaDB/engine/dms/dmsDump.cpp))在页元信息中**输出 `CRC Flag` 与
+  `CRC` 值**(FULL 时),便于人工核对;dump 本身不做校验(职责是导出内容)。
+
+### 3.5 崩溃一致性
+blk(含 crc)与 lobd 数据在同一写操作内、均被 DPS 覆盖;崩溃后按 DPS 回放同时重建 blk 与数据页,
+CRC 与数据保持一致。
+
+---
+
+## 4. 兼容性总表
+
+| 场景 | hash | CRC |
+|---|---|---|
+| 老文件(version<=2) | djb2(不变) | `_crcFlag=NONE`,不校验 |
+| 新文件(version=3) | MD5 | 按节点 mask 生成/校验,全写页 FULL |
+| 混合版本集群 | v3 门控在升级提交后创建的 CS | 无跨副本一致性要求 |
+| 备机回放 | 经 rtnWriteLob→set() **本机重算**(不用 DPS hash),依赖主备文件版本一致 | blk 随回放重建 |
+
+---
+
+## 5. 开发约束落实
+- **编译零告警**:新增函数/字段严格类型匹配;mask 解析、CRC 计算避免隐式截断;`_pad2` 重排后
+  `SDB_ASSERT(64==sizeof(_dmsLobDataMapBlk))` 保持通过。
+- **最小改动 & 模块归位**:
+  - 公共 hash/crc → `util`(`utilLobID.*` / 新增 `utilCrc32c`),与既有 `utilBsonHash` 同级风格。
+  - 版本缓存/`_calcHash`/CRC 生成校验 → `dms`(`dmsStorageLob.*` / `dmsLobDef.hpp`)。
+  - 节点参数 → `misc/autogen/optlist.xml`(生成宏)+ `pmd/pmdOptionsMgr.*`(成员/解析/getter)。
+  - 错误码 → `misc/autogen/rclist.xml`(注意跨分支 reserved 填充对齐)。
+  - inspect → `tools/sdbinspt.cpp`。
+  - **不改 `dps` 模块**(回放不用日志 hash)。
+- **命名风格**:沿用 `_camelCase` 成员、`utilXxx` / `PMD_OPTION_XXX` / `DMS_LOB_XXX` 宏、
+  `rc/goto done/error` 错误处理范式。
+
+---
+
+## 6. 测试计划(testcase_new,`./updateAll.sh` 一键编译运行)
+新增用例放 `testcase_new/story/js/lob/`(参照现有 `lob_*.js` 结构,`main(test)` + `testConf`):
+1. `lob_hashBalance_<id>.js`:大量写入 LOB 后,校验新 CS 的桶均衡性显著优于旧算法
+   (通过 `sdbinspt --dumplob` 输出解析 Variance/Max Depth,或 snapshot),并验证读写正确性。
+2. `lob_hashCompat_<id>.js`:老版本文件仍用旧算法可正常读写(升级兼容);新建 CS 走新算法。
+3. `lob_pageCrc_write_<id>.js`:`lobdatachecksum=write` 下写入后,inspect 报告 CRC 全部通过。
+4. `lob_pageCrc_read_<id>.js`:`lobdatachecksum=write|read` 下正常读通过;构造损坏页(工具/dump 定位)
+   验证 read 校验能报错。
+5. `lob_pageCrc_config_<id>.js`:运行时 `updateConf` 修改 mask,write/read 位分别生效。
+6. 复用/新增 inspect 断言:验证 "Page CRC Check" 统计段落存在且计数正确。
+
+**已落地用例(seqDB-60001 ~ 60012)**:
+- 正常路径:`lob_dataChecksum_readWrite_60001` / `lob_dataChecksum_configMask_60002` / `lob_hashMultiPiece_60003`。
+- 功能边缘:`lob_dataChecksum_emptyTiny_60004`(空/极小)、`lob_dataChecksum_pageBoundary_60005`(整页±1)、
+  `lob_dataChecksum_truncate_60006`(truncate 非页对齐)、`lob_dataChecksum_readNoCrc_60007`(read 校验读无 CRC 老数据不误报)、
+  `lob_dataChecksum_invalidMask_60008`(非法掩码优雅降级)。
+- 坏页检测(异常主场景):`lob_dataChecksum_corruptDetect_60009`(dd 篡改全副本 → getLob 报 `SDB_DMS_CORRUPTED_EXTENT`
+  + `sdbdmsdump inspect -C true` 报 Fail≥1 及 expect/actual 明细)、`lob_dataChecksum_inspectHealthy_60010`(健康基线 Fail 0)。
+- 非全写(RMW):`TestLobDataChecksumRMW60012.java`(java 用例,`lockAndSeek` 中途覆盖写 → 非全写页 NoCRC 不误报;
+  JS 高层 API 无法构造此场景,故用 java 覆盖)。
+- 公共 helper 见 `testcase_new/story/js/lob/commlib.js`:`lobGetGroupNodes`/`lobCorruptDataPage`/`lobInspectNode`/`lobParseCrcFail`。
+- hash 版本升级兼容(老版本装 LOB → 升级 → 读写)后续**手工**验证。
+> 每个用例分配 seqDB 编号,文件头注释按现有模板(@Description/@Author/...)。
+
+---
+
+## 7. 子任务拆分(见任务列表)
+1. util:`utilLobHash` + `utilCrc32c`(含声明/实现/编译)。
+2. dms 版本:`DMS_LOB_VERSION_3`、`_curVersion`、`_hashVersion` 缓存 + 填充/刷新。
+3. dms hash:`_dmsLobRecord::set` 传版本、`_calcHash` 替换所有重算点、`getBucketID` 加参、`hashVersion()` getter。
+4. rtn:各 `set()` 调用处传 `su->lob()->hashVersion()`。
+5. dms CRC 存储:`_dmsLobDataMapBlk` 增 `_crc/_crcFlag` 并保持 64B。
+6. pmd 参数:`lobdatachecksum` mask 参数(运行时可改)+ getter。
+7. dms CRC 生成:`_fillPage`/全写 `_updateWithPage` 生成 CRC。
+8. dms CRC 校验:`readPage` 按 read 位校验。
+9. tools:inspect 按版本选 hash;新增 Page CRC Check 报告。
+10. 测试:testcase_new 用例 6 项 + `./updateAll.sh` 跑通。
+11. 编译零告警自检 + 文档定稿。
+
+---
+
+## 7.5 独立 Agent Review 结论(依据本设计文档)
+
+由**独立 review agent** 对照本设计文档逐文件审查,结论:实现与设计一致,预期可零告警编译。发现并处理:
+
+| 级别 | 问题 | 处理 |
+|---|---|---|
+| Major | `utilGetCrc32cTable` 用手写 bool 守卫非线程安全(并发首用可能读到半初始化表 → 误报损坏) | **已修**:改用带非平凡构造的局部 `static const` 结构体,C++11 保证一次性线程安全初始化 |
+| Minor | `sdbinspt` CRC 读缓冲信任 `blk._dataLen ≤ 页大小`(inspect 面向可能损坏的文件,越界风险) | **已修**:增加 `blk._dataLen <= gLobdPageSize` 边界判断,超界跳过(该 blk 已由 inspectDmsLobDataMapBlk 标错) |
+| Minor(设计已知) | `read()` 在锁下取 expectCrc、解锁后 submit 再比对,并发整页覆盖可能误报 | 保留(SHARED 锁 + LOB 写序列化下极少发生);已在 §3.4 注明 |
+| Nit | `md5_append` 的 `size_t→int` 窄化 | 无害,与既有 `clsPartition` 同款写法,不产生新告警 |
+
+Review 复核通过的要点(节选):结构体仍为 64B 且 `_crc` 4 字节对齐;`_crcFlag` 在构造/reset/`_fillPage` 均初始化,部分更新必清;生成区间 `[0,dataLen)` 与读校验区间一致;MD5 与 `clsPartition` 逐字节相同;迁移只 v1→v2、v3 不降级;所有 `set()/getBucketID/dumpDmsLobDataMapBlk` 调用点均已传 hashType;util 不依赖 dms、链接安全。
+
+## 8. 风险
+- 混合版本主备 hash 不一致 → v3 门控在升级提交后创建的 CS 才启用。
+- `_pad2/_version` 复用:已核对 `reset()`/`isUndefined()`/inspect 均不依赖其值,安全。
+- read 校验开销:默认只 `write`,read 按需/诊断开启;子区间小读不校验。
+- CRC 算法一致性:统一 `utilCrc32c`,跨平台字节序一致。

--- a/doc/src/manual/Distributed_Engine/Maintainance/Mgmt_Tools/dmsdump.md
+++ b/doc/src/manual/Distributed_Engine/Maintainance/Mgmt_Tools/dmsdump.md
@@ -17,7 +17,7 @@ sdbdmsdump 是 SequoiaDB 巨杉数据库的数据文件检查工具，用于检�
 语法规则
 ----
 ```lang-text
-sdbdmsdump <--action | -a arg> [--dbpath | -d arg] [--output | -o arg] [ --dumpdata |-t arg] [--dumpindex | -i arg] [--dumplob | -b arg] [--record | -p arg]
+sdbdmsdump <--action | -a arg> [--dbpath | -d arg] [--output | -o arg] [ --dumpdata |-t arg] [--dumpindex | -i arg] [--dumplob | -b arg] [--crccheck | -C arg] [--record | -p arg]
 
 sdbdmsdump <--action | -a arg> [--dbpath | -d arg] [--output | -o arg] [ --csname | -c arg] [--dumpdata | -t arg]
 
@@ -49,6 +49,7 @@ sdbdmsdump --version | -v
 | --dumpdata  | -t   | 指定操作数据文件（取值为 true 或 false），默认值为 false                                 |
 | --dumpindex | -i   | 指定操作索引文件（取值为 true 或 false），默认值为 false                                 |
 | --dumplob   | -b   | 指定操作 Lob 文件（取值为 true 或者 false），默认值为 false                              |
+| --crccheck  | -C   | inspect 操作时，是否校验 Lob 数据页 CRC（取值为 true 或 false），默认值为 false。<br> 开启后会逐页回读 Lob 数据文件并重算 CRC 进行比对，耗时明显高于普通 inspect，故默认关闭，需要时显式开启。仅在 `--dumplob true` 且 `--action inspect`（或 all）时生效 |
 | --pagestart | -s   | dump操作时，指定起始数据页，默认为 -1                                                    |
 | --numpage   | -n   | dump操作时，指定数据页数量，默认值为 1；当指定 -s 参数为非负值时，该参数生效             |
 | --record    | -p   | dump操作时，指定显示格式化输出数据或索引内容（取值为 true 或 false），默认值为 false     |
@@ -290,6 +291,7 @@ sdbdmsdump --version | -v
        Total Lob Size    : 2614220545
        Lob Usage Rate    : 36.39%
        Total Lobs        : 17500
+       Page CRC Check    : skipped (use --crccheck true)
 
      Inspect Space Management Extent:
      Inspect Space Management Extent Done Succeed   [0.00 s]
@@ -304,6 +306,33 @@ sdbdmsdump --version | -v
      Free Tail Size  : 60.25 (MB)
      Total Free Size : 60.25 (MB)
    ```
+
+   其中 "Page CRC Check" 反映 Lob 数据页 CRC 校验结果。默认不校验，显示为 `skipped (use --crccheck true)`；仅当增加 `--crccheck true` 时才逐页比对，此时显示 `Pass N, Fail M, NoCRC K`（`Pass` 为校验通过页数，`Fail` 为校验失败页数，`NoCRC` 为未携带 CRC 而跳过的页数，如老版本数据、非全写页）。
+
+* 在上例基础上增加 `--crccheck true` 开启 Lob 数据页 CRC 校验，用于检测数据页是否损坏
+
+   ```lang-bash
+   $ sdbdmsdump -d /opt/sequoiadb/database/data/11830 -o outputlob.txt -c sample -a inspect -b true -C true
+   ```
+
+   校验通过时，"Page CRC Check" 显示各类页数统计；若存在损坏页，则每个损坏页额外打印一条明细，并计入 `Fail`，同时该集合的检测结果记录为 "Done with Errors"，显示内容可能如下：
+
+   ```lang-text
+     Inspect Lob for collection [0 : employee]
+   *** Error: Lob data page(1036) crc mismatch, expect[0x1a2b3c4d] actual[0x5e6f7a8b] dataLen[262144]
+     Inspect Lob for collection Done with Errors: 1   [0.85 s]
+       ++++ The collection lob info ++++
+       Collection ID     : 0
+       Total Lob Pages   : 27407
+       Total Lob Size    : 2614220545
+       Lob Usage Rate    : 36.39%
+       Total Lobs        : 17500
+       Page CRC Check    : Pass 25647, Fail 1, NoCRC 1759
+   ```
+
+   > **Note:**
+   >
+   > `expect` 为 Lob 元数据（lobm）中记录的 CRC，`actual` 为当前数据页（lobd）重算得到的 CRC，`dataLen` 为参与计算的数据长度。二者不一致说明数据页或其 CRC 记录已损坏。
 
 * 指定数据文件目录 `/opt/sequoiadb/database/data/11830`，指定集合空间 sample 设定操作数据文件，指定操作为“dump”将数据页格式化并输出至 `datadump.txt` 文件
 
@@ -603,7 +632,13 @@ sdbdmsdump --version | -v
     MB Id          : 0
     Status         : DMS_LOB_PAGE_NORMAL (0)
     New Flag       : DMS_LOB_PAGE_NEW (1)
-   ``` 
+    CRC Flag       : DMS_LOB_PAGE_CRC_FULL (1)
+    CRC            : 0x1a2b3c4d
+   ```
+
+   > **Note:**
+   >
+   > "CRC Flag" 表示该数据页的 CRC 状态：`DMS_LOB_PAGE_CRC_FULL` 表示整页写入并携带 CRC，`DMS_LOB_PAGE_CRC_NONE` 表示未携带 CRC（如老版本数据、非全写页）。仅当为 `DMS_LOB_PAGE_CRC_FULL` 时才输出 "CRC" 值。dump 操作仅展示 CRC 记录，不进行校验；如需校验请使用 `--action inspect --crccheck true`。
 
    如要该页为大对象的第0个分片，则会将大对象元数据进行输出，类似如下：
 

--- a/misc/autogen/optlist.xml
+++ b/misc/autogen/optlist.xml
@@ -1378,6 +1378,31 @@
    </opt>
 
    <opt>
+      <name>PMD_OPTION_LOB_DATA_CHECKSUM</name>
+      <long>lobdatachecksum</long>
+      <description>
+         <en>LOB data page checksum mask, value list: write,read, use '|' join multiple values, default: write. Empty value disables it</en>
+         <cn>大对象数据页校验掩码，取值列表为: write,read, 使用'|'连接多个取值, 默认值为write。空值表示关闭</cn>
+      </description>
+      <reloadable>
+         <en>Take effect immediately</en>
+         <cn>在线生效</cn>
+      </reloadable>
+      <reloadstrategy>
+         <en>takes effect upon newly written or read lob page</en>
+         <cn>新写入或读取的大对象页生效</cn>
+      </reloadstrategy>
+      <detail>
+         <en>1. It specifies the checksum mask of lob data page. "write" generates crc for fully written pages, "read" verifies crc when reading a whole page.<fig></fig>
+             2. If it is not specified, the default value is "write". Empty value disables the checksum.</en>
+         <cn>1. 指定大对象数据页的校验掩码。"write"表示对整页写入的页生成crc，"read"表示读取整页时校验crc。<fig></fig>
+             2. 如果不指定，则默认为"write"。空值表示关闭校验。</cn>
+      </detail>
+      <default>write</default>
+      <typeofweb>str</typeofweb>
+   </opt>
+
+   <opt>
       <name>PMD_OPTION_SPARSE_FILE</name>
       <long>sparsefile</long>
       <description>

--- a/testcase_new/story/java/src/test/java/com/sequoiadb/lob/basicoperation/TestLobDataChecksumRMW60012.java
+++ b/testcase_new/story/java/src/test/java/com/sequoiadb/lob/basicoperation/TestLobDataChecksumRMW60012.java
@@ -1,0 +1,102 @@
+package com.sequoiadb.lob.basicoperation;
+
+import java.util.Arrays;
+
+import org.bson.BasicBSONObject;
+import org.bson.types.ObjectId;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.sequoiadb.base.CollectionSpace;
+import com.sequoiadb.base.DBCollection;
+import com.sequoiadb.base.DBLob;
+import com.sequoiadb.base.Sequoiadb;
+import com.sequoiadb.lob.utils.LobOprUtils;
+import com.sequoiadb.testcommon.CommLib;
+import com.sequoiadb.testcommon.SdbTestBase;
+
+/**
+ * @Description seqDB-60012:开启lob数据页crc校验后,lockAndSeek中途覆盖写(RMW)
+ *              产生的"非全写页"不应误报crc错误,且数据正确。
+ *              该场景需低层lob写接口,JS高层API无法构造,故用java用例覆盖。
+ * @author Claude
+ * @Date 2026.07.02
+ * @version 1.00
+ */
+public class TestLobDataChecksumRMW60012 extends SdbTestBase {
+    private String clName = "cl_lobChecksumRMW60012";
+    private Sequoiadb sdb = null;
+    private CollectionSpace cs = null;
+    private DBCollection cl = null;
+    private static final int PAGE_SIZE = 262144; // 默认lob页大小256K
+
+    @BeforeClass
+    public void setUp() {
+        sdb = new Sequoiadb( SdbTestBase.coordUrl, "", "" );
+        if ( CommLib.isStandAlone( sdb ) ) {
+            throw new SkipException( "is standalone skip testcase" );
+        }
+        cs = sdb.getCollectionSpace( SdbTestBase.csName );
+        cl = LobOprUtils.createCL( cs, clName );
+        // 开启写生成 + 读校验
+        sdb.updateConfig(
+                new BasicBSONObject( "lobdatachecksum", "write|read" ) );
+    }
+
+    @Test
+    public void test() {
+        // 1) 写入多个整页数据(满写页,带crc)
+        int lobSize = PAGE_SIZE * 4;
+        byte[] lobBuff = LobOprUtils.getRandomBytes( lobSize );
+        ObjectId oid = LobOprUtils.createAndWriteLob( cl, lobBuff );
+
+        // 2) lockAndSeek 到页中间的非对齐偏移,覆盖写一小段(触发RMW)
+        int offset = PAGE_SIZE * 2 + 1000;
+        int rmwLen = 5000;
+        byte[] rmwBuff = LobOprUtils.getRandomBytes( rmwLen );
+        try ( DBLob wLob = cl.openLob( oid, DBLob.SDB_LOB_WRITE )) {
+            wLob.lockAndSeek( offset, rmwLen );
+            wLob.write( rmwBuff );
+        }
+
+        // 3) 构造期望数据:原数据在[offset,offset+rmwLen)处被覆盖
+        byte[] expBuff = Arrays.copyOf( lobBuff, lobSize );
+        System.arraycopy( rmwBuff, 0, expBuff, offset, rmwLen );
+
+        // 4) 开启读校验完整读回:RMW页为非全写页(NoCRC)不应报错,
+        //    其余满写页crc仍应校验通过,且整体数据正确
+        byte[] rBuff = new byte[ lobSize ];
+        try ( DBLob rLob = cl.openLob( oid, DBLob.SDB_LOB_READ )) {
+            int readLen = 0;
+            while ( readLen < lobSize ) {
+                int n = rLob.read( rBuff, readLen, lobSize - readLen );
+                if ( n <= 0 ) {
+                    break;
+                }
+                readLen += n;
+            }
+            Assert.assertEquals( readLen, lobSize, "read length mismatch" );
+        }
+        LobOprUtils.assertByteArrayEqual( rBuff, expBuff,
+                "lob data after RMW is wrong" );
+    }
+
+    @AfterClass
+    public void tearDown() {
+        try {
+            // 恢复默认配置
+            sdb.updateConfig(
+                    new BasicBSONObject( "lobdatachecksum", "write" ) );
+            if ( cs != null && cs.isCollectionExist( clName ) ) {
+                cs.dropCollection( clName );
+            }
+        } finally {
+            if ( sdb != null ) {
+                sdb.close();
+            }
+        }
+    }
+}

--- a/testcase_new/story/js/lob/commlib.js
+++ b/testcase_new/story/js/lob/commlib.js
@@ -135,3 +135,100 @@ function lobGetAllGroupNames ( db )
    }
    return groupnames;
 }
+
+/******************************************************************************
+ * 以下为 lob 数据页 CRC 校验相关的公共函数(供 hash/crc 边缘、异常用例复用)
+ * 内核常量:DMS_HEADER_SZ = 65536(64K),默认 lob 页大小 = 262144(256K)。
+ * lobd 文件布局:[64K header][pageID 0 .. n],pageID 0 为 meta,数据页从 1 起。
+ ******************************************************************************/
+var LOB_DMS_HEADER_SZ = 65536;    // 与内核 DMS_HEADER_SZ 一致
+var LOB_PAGE_SIZE = 262144;       // 默认 lob 页大小 256K
+
+// 获取指定组内所有节点(含 dbpath),返回 [{HostName, svcname, dbpath}]
+function lobGetGroupNodes ( db, groupName )
+{
+   var groups = commGetGroups( db );
+   for( var i = 0; i < groups.length; ++i )
+   {
+      if( groups[i][0].GroupName === groupName )
+      {
+         var nodes = [];
+         for( var j = 1; j < groups[i].length; ++j )
+         {
+            nodes.push( {
+               HostName: groups[i][j].HostName,
+               svcname: groups[i][j].svcname,
+               dbpath: groups[i][j].dbpath
+            } );
+         }
+         return nodes;
+      }
+   }
+   throw new Error( "lobGetGroupNodes: group not found: " + groupName );
+}
+
+// 计算某数据页在 lobd 文件中的字节偏移(pageID>=1 为数据页)
+function lobDataPageOffset ( pageID )
+{
+   if( undefined == pageID ) { pageID = 1; }
+   return LOB_DMS_HEADER_SZ + LOB_PAGE_SIZE * pageID + 100;
+}
+
+// dd 篡改指定主机上 lobd 的某数据页 1 字节(几乎必然与原字节不同 -> CRC 失配)。
+// 经该主机 sdbcm 的 Remote Cmd 执行,节点在远端也能正确注入。
+function lobCorruptNodeDataPage ( hostName, dbpath, csName, pageID, seq )
+{
+   if( undefined == seq ) { seq = 1; }
+   var offset = lobDataPageOffset( pageID );
+   var lobdFile = dbpath + "/" + csName + "." + seq + ".lobd";
+   var cmd = new Remote( hostName, CMSVCNAME ).getCmd();
+   cmd.run( "printf '\\xFF' | dd of=" + lobdFile + " bs=1 seek=" + offset +
+            " count=1 conv=notrunc 2>/dev/null" );
+}
+
+// 停节点 -> dd 篡改 lobd 指定数据页 1 字节 -> 起节点。作用于该组所有副本,
+// 使运行时 getLob(开启 read 校验)在任意主节点上都能触发 CRC 报错。
+// dd 经各节点所在主机的 sdbcm 执行(Remote),支持节点分布在远端主机。
+function lobCorruptDataPage ( db, groupName, csName, pageID, seq )
+{
+   var nodes = lobGetGroupNodes( db, groupName );
+   var rg = db.getRG( groupName );
+   for( var i = 0; i < nodes.length; ++i )
+   {
+      var node = nodes[i];
+      var dnode = rg.getNode( node.HostName, node.svcname );
+      dnode.stop();
+      lobCorruptNodeDataPage( node.HostName, node.dbpath, csName, pageID, seq );
+      dnode.start();
+   }
+   // 等待节点重新拉起、主选出
+   sleep( 5000 );
+}
+
+// 对单个节点(需已停机)运行 sdbdmsdump inspect(仅 lob),返回输出文本。
+// 停机运行避免读到打开中的文件。-C true 显式开启 lob 数据页 crc 校验
+// (默认关闭以免拖慢常规 inspect)。指定 csName 时用 -c 只检该 CS,
+// 避免扫到其它/系统 CS 导致 "Page CRC Check" 多段、解析错行。
+// sdbdmsdump 经节点所在主机的 sdbcm 执行(Remote),支持远端节点。
+function lobInspectNode ( hostName, dbpath, csName )
+{
+   var installPath = commGetRemoteInstallPath( hostName, CMSVCNAME );
+   var cmd = new Remote( hostName, CMSVCNAME ).getCmd();
+   var cmdStr = installPath + "/bin/sdbdmsdump -d " + dbpath +
+                " -a inspect -b true -C true";
+   if( undefined != csName )
+   {
+      cmdStr += " -c " + csName;
+   }
+   var out = cmd.run( cmdStr );
+   return out;
+}
+
+// 从 inspect 输出解析 "Page CRC Check : Pass N, Fail M, NoCRC K" 的 Fail 数,
+// 解析失败返回 -1。
+function lobParseCrcFail ( inspectOut )
+{
+   var m = inspectOut.match( /Page CRC Check\s*:\s*Pass\s+(\d+),\s*Fail\s+(\d+),\s*NoCRC\s+(\d+)/ );
+   if( null == m ) { return -1; }
+   return parseInt( m[2] );
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_configMask_60002.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_configMask_60002.js
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * @Description   : seqDB-60002:lobdatachecksum掩码在线切换(write/read/空)均正常put/get
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60002";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60002.file";
+   var getTestFile = CHANGEDPREFIX + "lob60002Get.file";
+   var masks = ["write", "write|read", "read", ""];
+
+   try
+   {
+      lobGenerateFile( testFile );
+      var originMd5 = getMd5ForFile( testFile );
+
+      for( var m = 0; m < masks.length; ++m )
+      {
+         // 在线修改掩码，运行时生效
+         db.updateConf( { "lobdatachecksum": masks[m] } );
+
+         var oid = cl.putLob( testFile );
+         cl.getLob( oid, getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ),
+                       "mask=" + masks[m] );
+         cl.deleteLob( oid );
+      }
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      var cmd = new Cmd();
+      cmd.run( "rm -rf " + testFile );
+      if( lobFileIsExist( getTestFile ) )
+      {
+         cmd.run( "rm -rf " + getTestFile );
+      }
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_corruptDetect_60009.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_corruptDetect_60009.js
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * @Description   : seqDB-60009:crc校验能检出被篡改的lob数据页(异常主场景)
+ *                  开启write|read写入多页lob,直接dd篡改该组所有副本的某数据页:
+ *                    1) 运行时getLob(read校验)报错 SDB_DMS_CORRUPTED_EXTENT
+ *                    2) 离线sdbdmsdump inspect报告 Page CRC Check Fail>=1
+ *                       且每坏页打印 expect/actual/dataLen 明细
+ *                  使用独立CS,避免污染公共集合;全程恢复节点并drop cs。
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+main( test );
+function test ()
+{
+   if( commIsStandalone( db ) )
+   {
+      return;
+   }
+
+   var csName = "lobcrc60009_cs";
+   var clName = "lobcrc60009_cl";
+   var fullCL = csName + "." + clName;
+   var testFile = CHANGEDPREFIX + "lob60009.file";
+   var getTestFile = CHANGEDPREFIX + "lob60009Get.file";
+   var cmd = new Cmd();
+   var corruptPageID = 1;   // page0为meta,篡改首个数据页
+   var groupName = null;
+   var nodes = null;
+
+   commDropCS( db, csName, true, "clean before test" );
+   commCreateCS( db, csName, true, "create cs" );
+   var cl = commCreateCL( db, csName, clName, {}, false, true, "create cl" );
+
+   try
+   {
+      db.updateConf( { "lobdatachecksum": "write|read" } );
+
+      // 写入多页lob(约1MB,>=4页),保证首个数据页为满写页(带crc)
+      cmd.run( "head -c " + ( 262144 * 4 ) + " /dev/urandom > " + testFile );
+      var oid = cl.putLob( testFile );
+
+      // 篡改前确认可正常读取
+      cl.getLob( oid, getTestFile, true );
+      cmd.run( "rm -rf " + getTestFile );
+
+      groupName = commGetCLGroups( db, fullCL )[0];
+      nodes = lobGetGroupNodes( db, groupName );
+      var rg = db.getRG( groupName );
+
+      // 逐副本:停机 -> 篡改数据页 -> 停机态跑inspect断言检出 -> 起机
+      // (dd/inspect 均经节点所在主机的 sdbcm 执行,支持远端节点)
+      var inspectChecked = false;
+      for( var i = 0; i < nodes.length; ++i )
+      {
+         var dnode = rg.getNode( nodes[i].HostName, nodes[i].svcname );
+         dnode.stop();
+         lobCorruptNodeDataPage( nodes[i].HostName, nodes[i].dbpath,
+                                 csName, corruptPageID );
+
+         // 离线inspect:应报Fail>=1且含 actual 明细(仅需在一个节点上断言)
+         if( !inspectChecked )
+         {
+            var out = lobInspectNode( nodes[i].HostName, nodes[i].dbpath,
+                                      csName );
+            var fail = lobParseCrcFail( out );
+            assert.notEqual( -1, fail, "inspect未输出Page CRC Check行:\n" + out );
+            assert.equal( true, fail >= 1,
+                          "inspect未检出坏页 Fail=" + fail + "\n" + out );
+            assert.equal( true, /crc mismatch/.test( out ),
+                          "inspect缺少坏页明细行\n" + out );
+            assert.equal( true, /actual\[0x/.test( out ),
+                          "inspect坏页明细缺少actual值\n" + out );
+            inspectChecked = true;
+         }
+         dnode.start();
+      }
+      sleep( 5000 );   // 等待重新选主
+
+      // 运行时getLob(read校验)应报数据页损坏
+      assert.tryThrow( SDB_DMS_CORRUPTED_EXTENT, function()
+      {
+         cl.getLob( oid, getTestFile, true );
+      } );
+   }
+   finally
+   {
+      // 兜底:确保所有节点已拉起
+      if( null != groupName && null != nodes )
+      {
+         var rg2 = db.getRG( groupName );
+         for( var k = 0; k < nodes.length; ++k )
+         {
+            try { rg2.getNode( nodes[k].HostName, nodes[k].svcname ).start(); }
+            catch( e ) {}
+         }
+         sleep( 3000 );
+      }
+      db.updateConf( { "lobdatachecksum": "write" } );
+      commDropCS( db, csName, true, "clean after test" );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_corruptGetLob_60011.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_corruptGetLob_60011.js
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * @Description   : seqDB-60011:运行时read校验独立检出坏页(不依赖离线工具)
+ *                  开启write|read写入多页lob,用公共函数lobCorruptDataPage
+ *                  篡改该组所有副本的同一数据页,getLob应报
+ *                  SDB_DMS_CORRUPTED_EXTENT。与60009的区别:仅验证运行时
+ *                  读路径,不做停机态inspect,作为最小化的运行时检测用例。
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.03
+ ******************************************************************************/
+main( test );
+function test ()
+{
+   if( commIsStandalone( db ) )
+   {
+      return;
+   }
+
+   var csName = "lobcrc60011_cs";
+   var clName = "lobcrc60011_cl";
+   var fullCL = csName + "." + clName;
+   var testFile = CHANGEDPREFIX + "lob60011.file";
+   var getTestFile = CHANGEDPREFIX + "lob60011Get.file";
+   var cmd = new Cmd();
+   var corruptPageID = 1;   // page0为meta,篡改首个数据页
+   var groupName = null;
+   var nodes = null;
+
+   commDropCS( db, csName, true, "clean before test" );
+   commCreateCS( db, csName, true, "create cs" );
+   var cl = commCreateCL( db, csName, clName, {}, false, true, "create cl" );
+
+   try
+   {
+      db.updateConf( { "lobdatachecksum": "write|read" } );
+
+      // 写入多页lob(4整页),保证首个数据页为满写页(带crc)
+      cmd.run( "head -c " + ( 262144 * 4 ) + " /dev/urandom > " + testFile );
+      var oid = cl.putLob( testFile );
+
+      // 篡改前确认可正常读取
+      cl.getLob( oid, getTestFile, true );
+      cmd.run( "rm -rf " + getTestFile );
+
+      groupName = commGetCLGroups( db, fullCL )[0];
+      nodes = lobGetGroupNodes( db, groupName );
+
+      // 公共函数:停机->dd篡改->起机,作用于该组所有副本(经sdbcm支持远端)
+      lobCorruptDataPage( db, groupName, csName, corruptPageID );
+
+      // 运行时getLob(read校验)应报数据页损坏
+      assert.tryThrow( SDB_DMS_CORRUPTED_EXTENT, function()
+      {
+         cl.getLob( oid, getTestFile, true );
+      } );
+   }
+   finally
+   {
+      // 兜底:确保所有节点已拉起
+      if( null != groupName && null != nodes )
+      {
+         var rg2 = db.getRG( groupName );
+         for( var k = 0; k < nodes.length; ++k )
+         {
+            try { rg2.getNode( nodes[k].HostName, nodes[k].svcname ).start(); }
+            catch( e ) {}
+         }
+         sleep( 3000 );
+      }
+      db.updateConf( { "lobdatachecksum": "write" } );
+      commDropCS( db, csName, true, "clean after test" );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_emptyTiny_60004.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_emptyTiny_60004.js
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * @Description   : seqDB-60004:开启crc校验后,空lob与极小lob的put/get数据完整
+ *                  边缘场景:dataLen=0 及远小于一页的数据,不应误报crc错误
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60004";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60004.file";
+   var getTestFile = CHANGEDPREFIX + "lob60004Get.file";
+   // 依次:空文件、1字节、几字节
+   var sizes = [0, 1, 7, 100];
+   var cmd = new Cmd();
+
+   db.updateConf( { "lobdatachecksum": "write|read" } );
+
+   try
+   {
+      for( var s = 0; s < sizes.length; ++s )
+      {
+         cmd.run( "rm -rf " + testFile + " " + getTestFile );
+         cmd.run( "head -c " + sizes[s] + " /dev/urandom > " + testFile );
+         var originMd5 = getMd5ForFile( testFile );
+
+         var oid = cl.putLob( testFile );
+         cl.getLob( oid, getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ),
+                       "size=" + sizes[s] );
+         cl.deleteLob( oid );
+      }
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_inspectHealthy_60010.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_inspectHealthy_60010.js
@@ -1,0 +1,79 @@
+/******************************************************************************
+ * @Description   : seqDB-60010:健康lob数据inspect基线(异常用例的对照组)
+ *                  开启write后putLob(一次性流式写入,含尾部不满页的每一页
+ *                  都是"整页一次写完"=全写页),离线inspect应:Fail=0,所有页
+ *                  计入 Pass(NoCRC 仅出现在RMW部分覆盖写,见java用例60012)。
+ *                  使用独立CS,停单节点跑inspect后恢复。
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+main( test );
+function test ()
+{
+   if( commIsStandalone( db ) )
+   {
+      return;
+   }
+
+   var csName = "lobcrc60010_cs";
+   var clName = "lobcrc60010_cl";
+   var fullCL = csName + "." + clName;
+   var testFile = CHANGEDPREFIX + "lob60010.file";
+   var cmd = new Cmd();
+   var groupName = null;
+   var node = null;
+
+   commDropCS( db, csName, true, "clean before test" );
+   commCreateCS( db, csName, true, "create cs" );
+   var cl = commCreateCL( db, csName, clName, {}, false, true, "create cl" );
+
+   try
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+
+      // 3整页(满写,带crc) + 尾部不满页(非全写,NoCRC)
+      cmd.run( "head -c " + ( 262144 * 3 + 500 ) + " /dev/urandom > " + testFile );
+      cl.putLob( testFile );
+
+      groupName = commGetCLGroups( db, fullCL )[0];
+      node = lobGetGroupNodes( db, groupName )[0];
+      var dnode = db.getRG( groupName ).getNode( node.HostName, node.svcname );
+
+      dnode.stop();
+      var out;
+      try
+      {
+         out = lobInspectNode( node.HostName, node.dbpath, csName );
+      }
+      finally
+      {
+         dnode.start();
+         sleep( 3000 );
+      }
+
+      var m = out.match( /Page CRC Check\s*:\s*Pass\s+(\d+),\s*Fail\s+(\d+),\s*NoCRC\s+(\d+)/ );
+      assert.notEqual( null, m, "inspect未输出Page CRC Check行:\n" + out );
+      var pass = parseInt( m[1] );
+      var fail = parseInt( m[2] );
+      var nocrc = parseInt( m[3] );
+      assert.equal( 0, fail, "健康数据不应有坏页 Fail=" + fail + "\n" + out );
+      assert.equal( true, pass >= 1, "全写页应计入Pass Pass=" + pass + "\n" + out );
+      // putLob 全部为全写页,NoCRC 应为 0(NoCRC 仅出现在 RMW,见 60012)
+      assert.equal( 0, nocrc, "putLob 数据不应产生 NoCRC 页 NoCRC=" + nocrc + "\n" + out );
+      // 不应出现坏页明细行
+      assert.equal( false, /crc mismatch/.test( out ),
+                    "健康数据出现坏页明细行\n" + out );
+   }
+   finally
+   {
+      if( null != groupName && null != node )
+      {
+         try { db.getRG( groupName ).getNode( node.HostName, node.svcname ).start(); }
+         catch( e ) {}
+         sleep( 2000 );
+      }
+      db.updateConf( { "lobdatachecksum": "write" } );
+      commDropCS( db, csName, true, "clean after test" );
+      cmd.run( "rm -rf " + testFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_invalidMask_60008.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_invalidMask_60008.js
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * @Description   : seqDB-60008:lobdatachecksum掩码取值边缘处理
+ *                  合法变体(乱序/重复)正常;非法token优雅降级为默认write不报错
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60008";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60008.file";
+   var getTestFile = CHANGEDPREFIX + "lob60008Get.file";
+   var cmd = new Cmd();
+   // 合法变体:乱序、重复,均应被规范化接受
+   var validMasks = ["read|write", "write|write", "write|read|write"];
+   // 非法token:内核记录"value error, use default"并回退默认write,不应报错
+   var invalidMasks = ["xxx", "Write", "readwrite", "write|foo"];
+
+   try
+   {
+      cmd.run( "head -c " + ( 262144 + 888 ) + " /dev/urandom > " + testFile );
+      var originMd5 = getMd5ForFile( testFile );
+
+      // 合法变体:配置成功且put/get正常
+      for( var i = 0; i < validMasks.length; ++i )
+      {
+         db.updateConf( { "lobdatachecksum": validMasks[i] } );
+         var oid = cl.putLob( testFile );
+         cl.getLob( oid, getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ),
+                       "validMask=" + validMasks[i] );
+         cl.deleteLob( oid );
+         cmd.run( "rm -rf " + getTestFile );
+      }
+
+      // 非法值:优雅降级,不抛异常,系统功能不受影响
+      for( var j = 0; j < invalidMasks.length; ++j )
+      {
+         db.updateConf( { "lobdatachecksum": invalidMasks[j] } );
+         var oid2 = cl.putLob( testFile );
+         cl.getLob( oid2, getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ),
+                       "invalidMask fallback=" + invalidMasks[j] );
+         cl.deleteLob( oid2 );
+         cmd.run( "rm -rf " + getTestFile );
+      }
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_pageBoundary_60005.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_pageBoundary_60005.js
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * @Description   : seqDB-60005:开启crc校验后,lob大小在页边界处put/get数据完整
+ *                  边缘场景:正好整数页、整数页±1字节,校验全写页与尾部不满页
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60005";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60005.file";
+   var getTestFile = CHANGEDPREFIX + "lob60005Get.file";
+   var page = 262144;   // 默认 lob 页大小 256K
+   // 1页-1、正好1页、1页+1、正好2页、2页+1
+   var sizes = [page - 1, page, page + 1, page * 2, page * 2 + 1];
+   var cmd = new Cmd();
+
+   db.updateConf( { "lobdatachecksum": "write|read" } );
+
+   try
+   {
+      for( var s = 0; s < sizes.length; ++s )
+      {
+         cmd.run( "rm -rf " + testFile + " " + getTestFile );
+         cmd.run( "head -c " + sizes[s] + " /dev/urandom > " + testFile );
+         var originMd5 = getMd5ForFile( testFile );
+
+         var oid = cl.putLob( testFile );
+         cl.getLob( oid, getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ),
+                       "size=" + sizes[s] );
+         cl.deleteLob( oid );
+      }
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_readNoCrc_60007.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_readNoCrc_60007.js
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * @Description   : seqDB-60007:read校验作用于"写入时未生成crc"的数据不误报
+ *                  边缘场景:先关write写入无crc页,再开read校验读取,应正常(NoCRC跳过)
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60007";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60007.file";
+   var getTestFile = CHANGEDPREFIX + "lob60007Get.file";
+   var cmd = new Cmd();
+
+   try
+   {
+      // 1) 关闭校验写入:数据页不携带 crc
+      db.updateConf( { "lobdatachecksum": "" } );
+      cmd.run( "head -c " + ( 262144 * 2 + 500 ) + " /dev/urandom > " + testFile );
+      var originMd5 = getMd5ForFile( testFile );
+      var oid = cl.putLob( testFile );
+
+      // 2) 仅开 read 校验读取:无 crc 的页应作 NoCRC 跳过,不报错
+      db.updateConf( { "lobdatachecksum": "read" } );
+      cl.getLob( oid, getTestFile, true );
+      assert.equal( originMd5, getMd5ForFile( getTestFile ) );
+
+      cl.deleteLob( oid );
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_readWrite_60001.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_readWrite_60001.js
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * @Description   : seqDB-60001:开启lob数据页crc校验(write|read)后put/get数据完整
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60001";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60001.file";
+   var getTestFile = CHANGEDPREFIX + "lob60001Get.file";
+   var putNum = 10;
+
+   // 开启写生成 + 读校验
+   db.updateConf( { "lobdatachecksum": "write|read" } );
+
+   try
+   {
+      lobGenerateFile( testFile );
+      var originMd5 = getMd5ForFile( testFile );
+
+      var oids = lobPutLob( cl, testFile, putNum );
+      for( var i = 0; i < oids.length; ++i )
+      {
+         // 读路径开启crc校验，数据正确应不报错且内容一致
+         cl.getLob( oids[i], getTestFile, true );
+         assert.equal( originMd5, getMd5ForFile( getTestFile ) );
+      }
+   }
+   finally
+   {
+      // 恢复默认配置
+      db.updateConf( { "lobdatachecksum": "write" } );
+      var cmd = new Cmd();
+      cmd.run( "rm -rf " + testFile );
+      if( lobFileIsExist( getTestFile ) )
+      {
+         cmd.run( "rm -rf " + getTestFile );
+      }
+   }
+}

--- a/testcase_new/story/js/lob/lob_dataChecksum_truncate_60006.js
+++ b/testcase_new/story/js/lob/lob_dataChecksum_truncate_60006.js
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * @Description   : seqDB-60006:开启crc校验后truncateLob到非页对齐长度,数据完整
+ *                  边缘场景:truncate产生的尾部不满页属"非全写页",不应误报crc错误
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60006";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60006.file";
+   var getTestFile = CHANGEDPREFIX + "lob60006Get.file";
+   var expectFile = CHANGEDPREFIX + "lob60006Expect.file";
+   var page = 262144;
+   var fullSize = page * 3;         // 3 整页
+   var truncLen = page * 2 + 12345; // 截断到非页对齐长度
+   var cmd = new Cmd();
+
+   db.updateConf( { "lobdatachecksum": "write|read" } );
+
+   try
+   {
+      cmd.run( "head -c " + fullSize + " /dev/urandom > " + testFile );
+      var oid = cl.putLob( testFile );
+
+      // 截断到非页对齐长度,尾页变为非全写页
+      cl.truncateLob( oid, truncLen );
+
+      // 读回并与原文件前 truncLen 字节比较
+      cl.getLob( oid, getTestFile, true );
+      cmd.run( "head -c " + truncLen + " " + testFile + " > " + expectFile );
+      assert.equal( getMd5ForFile( expectFile ), getMd5ForFile( getTestFile ),
+                    "truncLen=" + truncLen );
+
+      cl.deleteLob( oid );
+   }
+   finally
+   {
+      db.updateConf( { "lobdatachecksum": "write" } );
+      cmd.run( "rm -rf " + testFile + " " + getTestFile + " " + expectFile );
+   }
+}

--- a/testcase_new/story/js/lob/lob_hashMultiPiece_60003.js
+++ b/testcase_new/story/js/lob/lob_hashMultiPiece_60003.js
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * @Description   : seqDB-60003:新hash算法下多分片大lob的put/get/delete正确
+ * @Author        : Claude
+ * @CreateTime    : 2026.07.02
+ ******************************************************************************/
+testConf.clName = COMMCLNAME + "_60003";
+
+main( test );
+function test ( testPara )
+{
+   var cl = testPara.testCL;
+   var testFile = CHANGEDPREFIX + "lob60003.file";
+   var getTestFile = CHANGEDPREFIX + "lob60003Get.file";
+
+   try
+   {
+      // 生成较大文件，跨多个lobd页(多sequence)，覆盖新hash的多次入桶
+      lobGenerateFile( testFile, 50000 );
+      var originMd5 = getMd5ForFile( testFile );
+
+      var oid = cl.putLob( testFile );
+      cl.getLob( oid, getTestFile, true );
+      assert.equal( originMd5, getMd5ForFile( getTestFile ) );
+
+      // 删除后应查不到
+      cl.deleteLob( oid );
+      assert.equal( 0, cl.listLobs().toArray().length );
+   }
+   finally
+   {
+      var cmd = new Cmd();
+      cmd.run( "rm -rf " + testFile );
+      if( lobFileIsExist( getTestFile ) )
+      {
+         cmd.run( "rm -rf " + getTestFile );
+      }
+   }
+}


### PR DESCRIPTION
## Overview
Two LOB storage improvements:

1. **Bucket hash balance** — improve the LOB bucket hash to remove severe bucket imbalance (previously inspect reported large Variance / Max Depth, which lengthens bucket chains and slows LOB read/write).
2. **LOB data page CRC checksum** — detect corruption of LOB data pages (lobd).

## Changes
- **util**: `utilLobHash` (versioned) + `utilCrc32c` common helpers.
- **dms**: bump lobm to version 3, cache `_hashVersion` on the storage object; unify hash computation (`set()` takes the version, `_calcHash` replaces every recompute point). `_dmsLobDataMapBlk` carries `_crc`/`_crcFlag`, still 64B.
- **pmd**: new node config `lobdatachecksum` (mask `write|read`, runtime reloadable, default `write`). `write` generates CRC only for fully-written pages (no RMW, zero extra write IO); `read` verifies CRC on whole-page reads. Empty value disables it.
- **read verification**: on mismatch returns `SDB_DMS_CORRUPTED_EXTENT` and logs `piece/page/len/expect/actual` on the data node.
- **tools (sdbdmsdump)**: `dump` prints `CRC Flag`/`CRC`; `inspect` verifies CRC only when `--crccheck` (`-C`) is set (default off, to avoid slowing normal inspect), reporting `Page CRC Check: Pass/Fail/NoCRC` plus per-bad-page `expect/actual/dataLen`. inspect/dump also select hash by version so the balance report reflects the new distribution.

## Docs
`design_doc/` design doc, sdbdmsdump manual (`dmsdump.md`), and `optlist.xml` parameter entry.

## Tests
- JS `seqDB-60001..60010`: read/write, config mask online switch, multi-piece hash, empty/tiny, page boundary, truncate, read-on-no-CRC (no false error), invalid mask fallback, **corruption detection** (dd-tamper → getLob `SDB_DMS_CORRUPTED_EXTENT` + inspect `Fail>=1` with detail), healthy baseline.
- Java `TestLobDataChecksumRMW60012`: true `lockAndSeek` RMW → partial-update page is NoCRC and read does not false-fail.
- Full regression: **2324/2325 pass** (the only failure, `SystemLimits_10662`, is a pre-existing env-specific `ulimit` parsing issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)